### PR TITLE
ci: dynamic pr comment reaction

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,24 @@ runs:
             id: get_comment.id,
           };
 
+    # Add PR comment reaction to indicate that the workflow is running.
+    - name: Add reaction
+      id: reaction
+      if: steps.comment.outcome == 'success' || steps.commit.outcome == 'success'
+      env:
+        comment_id: ${{ github.event.comment.id || fromJSON(steps.comment.outputs.result)['id'] }}
+      uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
+      with:
+        result-encoding: string
+        retries: 3
+        script: |
+          return (await github.rest.reactions.createForIssueComment({
+            comment_id: process.env.comment_id,
+            content: "eyes",
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })).data.id;
+
     # Split and trim the PR comment, then parse it as an array of objects.
     # E.g., {tf:apply, chdir:path/to/dir, auto-approve:true}.
     - name: Parse command
@@ -108,19 +126,10 @@ runs:
       if: steps.comment.outcome == 'success' || steps.commit.outcome == 'success'
       env:
         comment_body: ${{ github.event.comment.body || fromJSON(steps.comment.outputs.result)['body'] }}
-        comment_id: ${{ github.event.comment.id || fromJSON(steps.comment.outputs.result)['id'] }}
       uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
       with:
         retries: 3
         script: |
-          // Add a reaction to the PR comment to indicate that the workflow is running.
-          const add_reaction = await github.rest.reactions.createForIssueComment({
-            comment_id: process.env.comment_id,
-            content: "eyes",
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-          });
-          //
           return process.env.comment_body
             // Split on newlines, removing empty lines and whitespace.
             .trim()
@@ -360,13 +369,13 @@ runs:
       id: apply
       if: fromJSON(steps.command.outputs.result)['tf'] == 'apply'
       shell: bash
-      run: $cli_uses ${{ steps.arguments.outputs.arg_chdir }} apply ${{ steps.arguments.outputs.arg_compact_warnings }} ${{ steps.arguments.outputs.arg_destroy }} ${{ steps.arguments.outputs.arg_lock }} ${{ steps.arguments.outputs.arg_lock_timeout }} ${{ steps.arguments.outputs.arg_parallelism }} ${{ steps.arguments.outputs.arg_refresh }} ${{ steps.arguments.outputs.arg_refresh_only }} ${{ steps.arguments.outputs.arg_replace }} ${{ steps.arguments.outputs.arg_target }} ${{ steps.arguments.outputs.arg_var_file }} ${{ steps.arguments.outputs.arg_auto_approve }}
+      run: ${{ inputs.cli_uses }} ${{ steps.arguments.outputs.arg_chdir }} apply ${{ steps.arguments.outputs.arg_compact_warnings }} ${{ steps.arguments.outputs.arg_destroy }} ${{ steps.arguments.outputs.arg_lock }} ${{ steps.arguments.outputs.arg_lock_timeout }} ${{ steps.arguments.outputs.arg_parallelism }} ${{ steps.arguments.outputs.arg_refresh }} ${{ steps.arguments.outputs.arg_refresh_only }} ${{ steps.arguments.outputs.arg_replace }} ${{ steps.arguments.outputs.arg_target }} ${{ steps.arguments.outputs.arg_var_file }} ${{ steps.arguments.outputs.arg_auto_approve }}
 
     - name: TF force-unlock
       id: force_unlock
       if: fromJSON(steps.command.outputs.result)['tf'] == 'force-unlock'
       shell: bash
-      run: $cli_uses ${{ steps.arguments.outputs.arg_chdir }} force-unlock -force "${{ fromJSON(steps.command.outputs.result)['lock-id'] }}"
+      run: ${{ inputs.cli_uses }} ${{ steps.arguments.outputs.arg_chdir }} force-unlock -force "${{ fromJSON(steps.command.outputs.result)['lock-id'] }}"
 
     # Render TF output with reduced verbosity for PR comment legibility.
     - name: Render TF output
@@ -399,10 +408,12 @@ runs:
     - name: Comment TF output
       if: ${{ (success() || failure()) && steps.render.outcome == 'success' }}
       env:
+        comment_id: ${{ github.event.comment.id || fromJSON(steps.comment.outputs.result)['id'] }}
+        reaction_id: ${{ steps.reaction.outputs.result }}
         tf_command: ${{ steps.command.outputs.result }}
         tf_fmt: ${{ steps.render.outputs.tf_fmt }}
-        tf_plan_id: ${{ steps.arguments.outputs.tf_plan_id }}
         tf_output: ${{ steps.render.outputs.tf_output }}
+        tf_plan_id: ${{ steps.arguments.outputs.tf_plan_id }}
       uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
       with:
         retries: 3
@@ -451,6 +462,14 @@ runs:
               comment.user.type === "Bot" &&
               comment.body.includes(`<!-- ${process.env.tf_plan_id} -->`)
             );
+          });
+
+          // Delete PR comment reaction to indicate that the workflow has ended.
+          const delete_reaction = await github.rest.reactions.deleteForIssueComment({
+            comment_id: process.env.comment_id,
+            owner: context.repo.owner,
+            reaction_id: process.env.reaction_id,
+            repo: context.repo.repo,
           });
 
           // If a bot comment exists with a matching TFPLAN identifier, then update

--- a/stacks/sample_instance/main.tf
+++ b/stacks/sample_instance/main.tf
@@ -24,3 +24,4 @@ output "sample_instance_id" {
   description = "ID of the sample EC2 instance."
   value       = aws_instance.sample.id
 }
+

--- a/stacks/sample_instance/main.tf
+++ b/stacks/sample_instance/main.tf
@@ -24,4 +24,3 @@ output "sample_instance_id" {
   description = "ID of the sample EC2 instance."
   value       = aws_instance.sample.id
 }
-


### PR DESCRIPTION
**Use-case scenario**
Provision resources in a workspaces with input variables, followed by targeted destruction.

For demo purposes, I have split out `plan` and `apply` outputs to separate comments, instead of updating the same one.

```bash
#1 PR Comment: Plan configuration in a workspace with input variable file.
-tf=plan -chdir=sample_instance -workspace=dev -var-file=env/dev.tfvars

#2 PR Comment: Apply configuration in a workspace with input variable file.
-tf=apply -chdir=sample_instance -workspace=dev -var-file=env/dev.tfvars

#3 PR Comment: Plan destruction of targeted resources in a workspace with input variable file.
-tf=plan -destroy -target=aws_instance.sample,data.aws_ami.ubuntu -chdir=sample_instance -workspace=dev -var-file=env/dev.tfvars

#4 PR Comment: Apply destruction of targeted resources in a workspace with input variable file.
-tf=apply -destroy -target=aws_instance.sample,data.aws_ami.ubuntu -chdir=sample_instance -workspace=dev -var-file=env/dev.tfvars
```
