### PR TITLE
Provision resources with a backend, followed by destruction without confirmation

### DIFF
--- a/stacks/sample_bucket/main.tf
+++ b/stacks/sample_bucket/main.tf
@@ -11,3 +11,4 @@ output "sample_bucket_id" {
   description = "ID of the sample S3 bucket."
   value        = module.sample_bucket.id
 }
+


### PR DESCRIPTION
**Use-case scenario**
Provision resources with a backend, followed by destruction without confirmation.

For demo purposes, I have split out `plan` and `apply` outputs to separate comments, instead of updating the same one.


```bash
#1 PR Comment: Plan configuration with a backend.
-tf=plan -chdir=sample_bucket -backend-config=backend/dev.tfbackend

#2 PR Comment: Apply configuration with a backend.
-tf=apply -chdir=sample_bucket -backend-config=backend/dev.tfbackend

#3 PR Comment: Destroy configuration with a backend without confirmation.
-tf=apply -destroy -auto-approve -chdir=sample_bucket -backend-config=backend/dev.tfbackend
```
