### PR TITLE
fix: await resource initialization

### DIFF
--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -48,6 +48,10 @@ jobs:
           command_input: ${{ format('-tf={0} -chdir=stacks/sample_instance -var-file=env/{1}.tfvars', github.event.action != 'closed' && 'plan' || 'apply', matrix.context) }}
           cache_plugins: false
 
+      - name: Await resource initialization
+        if: github.event.action == 'closed'
+        run: sleep 60
+
       - name: Deprovision TF
         if: github.event.action == 'closed'
         uses: ./
@@ -84,6 +88,10 @@ jobs:
         with:
           command_input: ${{ format('-tf={0} -chdir=stacks/sample_bucket -backend-config=backend/{1}.tfbackend', github.event.action != 'closed' && 'plan' || 'apply', matrix.context) }}
           cache_plugins: false
+
+      - name: Await resource initialization
+        if: github.event.action == 'closed'
+        run: sleep 60
 
       - name: Deprovision TF
         if: github.event.action == 'closed'

--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -3,7 +3,7 @@ name: TF Sample
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
-    paths: [stacks/sample_instance/**]
+    paths: [.github/workflows/tf_sample.yaml, stacks/**/*]
 
 permissions:
   actions: read # Required for workflow query and artifact download.


### PR DESCRIPTION
In order to ensure AWS resources provisioned by TF have a chance to initialize before being deprovisioned again.