### PR TITLE
docs: arg_lock and setup

### DIFF
--- a/.github/examples/pr_merge_matrix.yaml
+++ b/.github/examples/pr_merge_matrix.yaml
@@ -34,6 +34,6 @@ jobs:
         with:
           arg_chdir: directory/path
           arg_command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
+          arg_lock: ${{ github.event_name == 'merge_group' && 'true' || 'false' }}
           arg_var_file: env/${{ matrix.deployment }}.tfvars
           arg_workspace: ${{ matrix.deployment }}
-          arg_lock: ${{ github.event_name == 'merge_group' && 'true' || 'false' }}

--- a/.github/examples/pr_push_auth.yaml
+++ b/.github/examples/pr_push_auth.yaml
@@ -35,3 +35,4 @@ jobs:
         with:
           arg_chdir: directory/path
           arg_command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+          arg_lock: ${{ github.event_name == 'push' && 'true' || 'false' }}

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           arg_chdir: tests/${{ matrix.path }}
           arg_command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
           tf_tool: ${{ matrix.tool }}
           tf_version: ~> 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: opentofu/setup-opentofu@v1
       - uses: devsectop/tf-via-pr@v11
         with:
-          arg_command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           arg_chdir: sample/directory/path
-          arg_workspace: development
+          arg_command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+          arg_lock: ${{ github.event_name == 'push' && 'true' || 'false' }}
           arg_var_file: env/dev.tfvars
-          tf_version: ~> 1.8.0
+          arg_workspace: development
 ```
 
 > [!TIP]


### PR DESCRIPTION
- Include `arg_lock` in all example workflows.
- Replace `tf_version` with dedicated TF setup step to simplify "getting started".