### PR TITLE
ci: fix event trigger

### DIFF
--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths: [.github/workflows/tf_sample.yaml, sample/**]
   push:
+    paths: [.github/workflows/tf_sample.yaml, sample/**]
     branches: [main]
 
 env:


### PR DESCRIPTION
To prevent erroneous runs of TF Sample workflow on merge to `main` branch.