### PR TITLE
feat: encrypt plan file with openssl

### DIFF
--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -57,3 +57,5 @@ jobs:
           arg_var_file: ${{ contains(matrix.dir, 'instance') && format('env/{0}.tfvars', matrix.env) || '' }}
           arg_workspace: ${{ matrix.env }}
           arg_or_create: true
+          cache_plugins: true
+          encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -51,6 +51,7 @@ jobs:
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
           tf_tool: ${{ matrix.tool }}
           tf_version: ~> 1.8.0
+          encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -51,7 +51,6 @@ jobs:
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
           tf_tool: ${{ matrix.tool }}
           tf_version: ~> 1.8.0
-          encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}
 
       - name: Echo TF
         run: |

--- a/README.md
+++ b/README.md
@@ -98,21 +98,32 @@ The following functional workflow examples demonstrate common use-cases, while a
 - [Trigger](.github/examples/pr_merge_matrix.yaml) on `pull_request` (plan) and `merge_group` (apply) events with OpenTofu in **matrix** strategy.
 - [Trigger](.github/examples/pr_tenv.yaml) on `pull_request` (plan or apply) event with [tenv](https://tofuutils.github.io/tenv/) to avoid TF **wrapper**.
 
+### How does encryption work?
+
+Before the workflow uploads the TF plan file as an artifact, it can be encrypted with a passphrase to prevent exposure of sensitive data using `encrypt_passphrase` input with a secret. This is done with [OpenSSL](https://docs.openssl.org/master/man1/openssl-enc/)'s symmetric stream counter mode encryption with salt and pbkdf2.
+
+In order to locally decrypt the TF plan file, use the following command (noting the whitespace prefix to prevent recording the command in shell history):
+
+```sh
+ openssl enc -aes-256-ctr -pbkdf2 -salt -in <tfplan> -out <tfplan.decrypted> -pass pass:<passphrase> -d
+```
+
 ## Parameters
 
 ### Inputs - Configuration
 
-| Name                                 | Description                                                                                            |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `cache_plugins`</br>Default: false   | Boolean flag to cache TF plugins for faster workflow runs (requires .terraform.lock.hcl file).         |
-| `comment_pr`</br>Default: true       | Boolean flag to add PR comment of TF command output.                                                   |
-| `fmt_enable`</br>Default: true       | Boolean flag to enable TF fmt command and display diff of changes.                                     |
-| `label_pr`</br>Default: true         | Boolean flag to add PR label of TF command to run.                                                     |
-| `outline_enable`</br>Default: true   | Boolean flag to add an outline diff of TF plan file.                                                   |
-| `tf_tool`</br>Default: terraform     | String name of the TF tool to use and override default assumption from wrapper environment variable.   |
-| `tf_version`</br>Example: ~> 1.8.0   | String version constraint of the TF tool to install and use.                                           |
-| `update_comment`</br>Default: false  | Boolean flag to update existing PR comment instead of creating a new comment and deleting the old one. |
-| `validate_enable`</br>Default: false | Boolean flag to enable TF validate command check.                                                      |
+| Name                                                   | Description                                                                                            |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `cache_plugins`</br>Default: `false`                   | Boolean flag to cache TF plugins for faster workflow runs (requires .terraform.lock.hcl file).         |
+| `comment_pr`</br>Default: `true`                       | Boolean flag to add PR comment of TF command output.                                                   |
+| `encrypt_passphrase`</br>Example: `${{ secrets.KEY }}` | String passphrase to encrypt the TF plan file.                                                         |
+| `fmt_enable`</br>Default: `true`                       | Boolean flag to enable TF fmt command and display diff of changes.                                     |
+| `label_pr`</br>Default: `true`                         | Boolean flag to add PR label of TF command to run.                                                     |
+| `outline_enable`</br>Default: `true`                   | Boolean flag to add an outline diff of TF plan file.                                                   |
+| `tf_tool`</br>Default: `terraform`                     | String name of the TF tool to use and override default assumption from wrapper environment variable.   |
+| `tf_version`</br>Example: `~>` 1.8.0                   | String version constraint of the TF tool to install and use.                                           |
+| `update_comment`</br>Default: `false`                  | Boolean flag to update existing PR comment instead of creating a new comment and deleting the old one. |
+| `validate_enable`</br>Default: `false`                 | Boolean flag to enable TF validate command check.                                                      |
 
 ### Inputs - Arguments
 

--- a/action.js
+++ b/action.js
@@ -309,9 +309,15 @@ module.exports = async ({ context, core, exec, github }) => {
           "-aes-256-ctr",
           "-d",
           "-in",
-          `${process.env.arg_chdir.replace(/^-chdir=/, "")}/tfplan`,
+          `${process.env.arg_chdir.replace(/^-chdir=/, "")}/${process.env.arg_out.replace(
+            /^-out=/,
+            ""
+          )}`,
           "-out",
-          `${process.env.arg_chdir.replace(/^-chdir=/, "")}/tfplan`,
+          `${process.env.arg_chdir.replace(/^-chdir=/, "")}/${process.env.arg_out.replace(
+            /^-out=/,
+            ""
+          )}`,
           "-pass",
           "file:$TEMP_FILE",
         ]);

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Boolean flag to add PR comment of TF command output.
     required: false
     default: "true"
+  encrypt_passphrase:
+    description: String passphrase to encrypt the TF plan file.
+    required: false
+    default: ""
   fmt_enable:
     description: Boolean flag to enable TF fmt command and display diff of changes.
     required: false
@@ -278,6 +282,7 @@ runs:
         # Input parameters.
         cache_hit: ${{ steps.cache_plugins.outputs.cache-hit }}
         comment_pr: ${{ inputs.comment_pr }}
+        encrypt_passphrase: ${{ inputs.encrypt_passphrase }}
         fmt_enable: ${{ inputs.fmt_enable }}
         label_pr: ${{ inputs.label_pr }}
         outline_enable: ${{ inputs.outline_enable }}
@@ -340,6 +345,19 @@ runs:
         retries: 3
         result-encoding: string
         script: await require(`${process.env.GITHUB_ACTION_PATH}/action.js`)({ context, core, exec, github });
+
+    # OpenSSL 3.0.2-0ubuntu1.17 https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
+    # Encrypt https://docs.openssl.org/3.0/man1/openssl-enc/
+    # Passphrase https://docs.openssl.org/3.0/man1/openssl-passphrase-options/
+    - name: Encrypt TF plan file
+      if: inputs.encrypt_passphrase != ''
+      env:
+        encrypt_passphrase: ${{ inputs.encrypt_passphrase }}
+      shell: bash
+      run: |
+        TEMP_FILE=$(mktemp)
+        printf %s "$encrypt_passphrase" >"$TEMP_FILE"
+        openssl enc -aes-256-ctr -in "${{ inputs.arg_chdir }}/${{ inputs.arg_out }}" -out "${{ inputs.arg_chdir }}/${{ inputs.arg_out }}" -pass file:"$TEMP_FILE"
 
     - name: Upload TF plan file
       if: inputs.arg_command == 'plan'

--- a/action.yml
+++ b/action.yml
@@ -346,18 +346,17 @@ runs:
         result-encoding: string
         script: await require(`${process.env.GITHUB_ACTION_PATH}/action.js`)({ context, core, exec, github });
 
-    # OpenSSL 3.0.2-0ubuntu1.17 https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
-    # Encrypt https://docs.openssl.org/3.0/man1/openssl-enc/
-    # Passphrase https://docs.openssl.org/3.0/man1/openssl-passphrase-options/
     - name: Encrypt TF plan file
       if: inputs.encrypt_passphrase != ''
       env:
         encrypt_passphrase: ${{ inputs.encrypt_passphrase }}
+        working_directory: ${{ inputs.arg_chdir }}/${{ inputs.arg_out }}
       shell: bash
       run: |
         TEMP_FILE=$(mktemp)
-        printf %s "$encrypt_passphrase" >"$TEMP_FILE"
-        openssl enc -aes-256-ctr -in "${{ inputs.arg_chdir }}/${{ inputs.arg_out }}" -out "${{ inputs.arg_chdir }}/${{ inputs.arg_out }}" -pass file:"$TEMP_FILE"
+        printf %s "$encrypt_passphrase" > "$TEMP_FILE"
+        openssl enc -aes-256-ctr -pbkdf2 -salt -in "$working_directory" -out "$working_directory.encrypted" -pass file:"$TEMP_FILE"
+        mv "$working_directory.encrypted" "$working_directory"
 
     - name: Upload TF plan file
       if: inputs.arg_command == 'plan'


### PR DESCRIPTION
### What?

Provide an option to encrypt TF plan file before uploading as a repository artifact to prevent exposure of stored secrets.

### How?

- The [latest ubuntu runners](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools) (as of today) ship with OpenSSL 3.0.2-0ubuntu1.17.
- OpenSSL allows [de-/encryption](https://docs.openssl.org/3.0/man1/openssl-enc/) via [passphrase](https://docs.openssl.org/3.0/man1/openssl-passphrase-options/).
- Enable users to simply pass in `encrypt_passphrase: ${{ secrets.encryption_key }}`.

### Considerations

- Opted for "aes-256-ctr" (stream cipher mode) for bettter performance via parallelization, along with salt and pbkdf2.
- Must ~double~ triple-check that secrets passed in via `encrypt_passphrase` input is property masked in GitHub Action workflow logs.
- Update documention to clarify manual decryption method.

In order to locally decrypt the TF plan file, use the following command (noting the whitespace prefix to prevent recording the command in shell history):

```sh
 openssl enc -aes-256-ctr -pbkdf2 -salt -in <tfplan> -out <tfplan.decrypted> -pass pass:<passphrase> -d
```
