### PR TITLE
feat: pin `tenv` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ In order to locally decrypt the TF plan file, use the following command (noting 
 | `fmt_enable`</br>Default: `true`                       | Boolean flag to enable TF fmt command and display diff of changes.                                     |
 | `label_pr`</br>Default: `true`                         | Boolean flag to add PR label of TF command to run.                                                     |
 | `plan_parity`</br>Default: `false`                     | Boolean flag to compare the TF plan file with a newly-generated one to prevent stale apply.            |
+| `tenv_version`</br>Example: `v3.1.0`                   | String version tag of the tenv tool to install and use.                                                |
 | `tf_tool`</br>Default: `terraform`                     | String name of the TF tool to use and override default assumption from wrapper environment variable.   |
 | `tf_version`</br>Example: `~>` 1.8.0                   | String version constraint of the TF tool to install and use.                                           |
 | `update_comment`</br>Default: `false`                  | Boolean flag to update existing PR comment instead of creating a new comment and deleting the old one. |

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,6 @@ inputs:
     description: Boolean flag to add PR comment of TF command output.
     required: false
     default: "true"
-  plan_parity:
-    description: Boolean flag to compare the TF plan file with a newly-generated one to prevent stale apply.
-    required: false
-    default: "false"
   encrypt_passphrase:
     description: String passphrase to encrypt the TF plan file.
     required: false
@@ -32,6 +28,10 @@ inputs:
     description: Boolean flag to add PR label of TF command to run.
     required: false
     default: "true"
+  plan_parity:
+    description: Boolean flag to compare the TF plan file with a newly-generated one to prevent stale apply.
+    required: false
+    default: "false"
   tf_tool:
     description: String name of the TF tool to use and override default assumption from wrapper environment variable.
     required: false
@@ -282,10 +282,10 @@ runs:
         # Input parameters.
         cache_hit: ${{ steps.cache_plugins.outputs.cache-hit }}
         comment_pr: ${{ inputs.comment_pr }}
-        plan_parity: ${{ inputs.plan_parity }}
         encrypt_passphrase: ${{ inputs.encrypt_passphrase }}
         fmt_enable: ${{ inputs.fmt_enable }}
         label_pr: ${{ inputs.label_pr }}
+        plan_parity: ${{ inputs.plan_parity }}
         tf_tool: ${{ inputs.tf_tool }}
         update_comment: ${{ inputs.update_comment }}
         validate_enable: ${{ inputs.validate_enable }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Boolean flag to compare the TF plan file with a newly-generated one to prevent stale apply.
     required: false
     default: "false"
+  tenv_version:
+    description: String version tag of the tenv tool to install and use.
+    required: false
+    default: ""
   tf_tool:
     description: String name of the TF tool to use and override default assumption from wrapper environment variable.
     required: false
@@ -265,13 +269,16 @@ runs:
     - name: Install TF via tenv
       if: inputs.tf_version != ''
       env:
+        TENV_VERSION: ${{ inputs.tenv_version }}
         TF_TOOL: ${{ inputs.tf_tool }}
         TF_VERSION: ${{ inputs.tf_version }}
       shell: bash
       run: |
-        VERSION=$(curl --no-progress-meter --location https://api.github.com/repos/tofuutils/tenv/releases/latest | jq -r .tag_name)
-        curl --remote-name --no-progress-meter --location "https://github.com/tofuutils/tenv/releases/latest/download/tenv_${VERSION}_amd64.deb"
-        sudo dpkg --install "tenv_${VERSION}_amd64.deb"
+        if [ -z "$TENV_VERSION" ]; then
+          TENV_VERSION=$(curl --no-progress-meter --location https://api.github.com/repos/tofuutils/tenv/releases/latest | jq -r .tag_name)
+        fi
+        curl --remote-name --no-progress-meter --location "https://github.com/tofuutils/tenv/releases/latest/download/tenv_${TENV_VERSION}_amd64.deb"
+        sudo dpkg --install "tenv_${TENV_VERSION}_amd64.deb"
         tenv "$TF_TOOL" install "$TF_VERSION"
         tenv update-path
 


### PR DESCRIPTION
Necessitated due to reports of breaking changes brought about by tenv [v3.2.0](https://github.com/tofuutils/tenv/releases/tag/v3.2.0) (PR https://github.com/tofuutils/tenv/pull/247).