### PR TITLE
feat: expose tf exitcode

### DIFF
--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -63,8 +63,8 @@ jobs:
           echo "identifier: ${{ steps.tf.outputs.identifier }}"
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
-          echo "stderr: ${{ steps.tf.outputs.stderr }}"
-          echo "summary: ${{ steps.tf.outputs.summary }}"
-          if [[ "${{ matrix.test }}" != "pass_character_limit" ]]; then
-            echo "stdout: ${{ steps.tf.outputs.stdout }}"
-          fi
+          # echo "stderr: ${{ steps.tf.outputs.stderr }}"
+          # echo "summary: ${{ steps.tf.outputs.summary }}"
+          # if [[ "${{ matrix.test }}" != "pass_character_limit" ]]; then
+          #   echo "stdout: ${{ steps.tf.outputs.stdout }}"
+          # fi

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         tool: [tofu, terraform]
         path:
-          - fail_invalid_resource_type
+          # - fail_invalid_resource_type
           - fail_data_source_error
           - pass_one
-          - pass_character_limit
-          - pass_format_diff
+          # - pass_character_limit
+          # - pass_format_diff
 
     steps:
       - name: Echo github

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         tool: [tofu, terraform]
-        path:
+        test:
           - fail_invalid_resource_type
           - fail_data_source_error
           - pass_one
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          arg_chdir: tests/${{ matrix.path }}
+          arg_chdir: tests/${{ matrix.test }}
           arg_command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
           arg_detailed_exitcode: true
@@ -64,5 +64,7 @@ jobs:
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
           echo "stderr: ${{ steps.tf.outputs.stderr }}"
-          echo "stdout: ${{ steps.tf.outputs.stdout }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
+          if [[ "${{ matrix.test }}" != "pass_character_limit" ]]; then
+            echo "stdout: ${{ steps.tf.outputs.stdout }}"
+          fi

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,6 +54,7 @@ jobs:
           tf_version: ~> 1.8.0
 
       - name: Echo TF
+        # continue-on-error: true
         run: |
           echo "check_id: ${{ steps.tf.outputs.check_id }}"
           echo "comment_id: ${{ steps.tf.outputs.comment_id }}"
@@ -63,8 +64,6 @@ jobs:
           echo "identifier: ${{ steps.tf.outputs.identifier }}"
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
-          # echo "stderr: ${{ steps.tf.outputs.stderr }}"
-          # echo "summary: ${{ steps.tf.outputs.summary }}"
-          # if [[ "${{ matrix.test }}" != "pass_character_limit" ]]; then
-          #   echo "stdout: ${{ steps.tf.outputs.stdout }}"
-          # fi
+          echo "stderr: ${{ steps.tf.outputs.stderr }}"
+          echo "stdout: ${{ steps.tf.outputs.stdout }}"
+          echo "summary: ${{ steps.tf.outputs.summary }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,7 +54,7 @@ jobs:
           tf_version: ~> 1.8.0
 
       - name: Echo TF
-        # continue-on-error: true
+        continue-on-error: true
         run: |
           echo "check_id: ${{ steps.tf.outputs.check_id }}"
           echo "comment_id: ${{ steps.tf.outputs.comment_id }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -63,6 +63,6 @@ jobs:
           echo "identifier: ${{ steps.tf.outputs.identifier }}"
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
-          echo "stderr": ${{ steps.tf.outputs.stderr }}
-          echo "stdout": ${{ steps.tf.outputs.stdout }}
+          echo "stderr: ${{ steps.tf.outputs.stderr }}"
+          echo "stdout: ${{ steps.tf.outputs.stdout }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -41,6 +41,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Setup TF
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ~> 1.8.0
+
       - name: Provision TF
         id: tf
         continue-on-error: true
@@ -50,8 +55,8 @@ jobs:
           arg_chdir: tests/${{ matrix.path }}
           arg_command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
-          tf_tool: ${{ matrix.tool }}
-          tf_version: ~> 1.8.0
+          # tf_tool: ${{ matrix.tool }}
+          # tf_version: ~> 1.8.0
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         tool: [tofu, terraform]
         path:
-          # - fail_invalid_resource_type
+          - fail_invalid_resource_type
           - fail_data_source_error
           - pass_one
-          # - pass_character_limit
-          # - pass_format_diff
+          - pass_character_limit
+          - pass_format_diff
 
     steps:
       - name: Echo github

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -41,33 +41,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Setup TF
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ~> 1.8.0
-
       - name: Provision TF
         id: tf
         continue-on-error: true
         uses: ./
         with:
-          plan_parity: true
           arg_chdir: tests/${{ matrix.path }}
           arg_command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
-          # tf_tool: ${{ matrix.tool }}
-          # tf_version: ~> 1.8.0
+          arg_detailed_exitcode: true
+          plan_parity: true
+          tf_tool: ${{ matrix.tool }}
+          tf_version: ~> 1.8.0
 
       - name: Echo TF
         run: |
           echo "check_id: ${{ steps.tf.outputs.check_id }}"
           echo "comment_id: ${{ steps.tf.outputs.comment_id }}"
+          echo "exitcode: ${{ steps.tf.outputs.exitcode }}"
           echo "fmt_result: ${{ steps.tf.outputs.fmt_result }}"
           echo "header: ${{ steps.tf.outputs.header }}"
           echo "identifier: ${{ steps.tf.outputs.identifier }}"
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
-          echo "tf_exitcode: ${{ steps.tf.outputs.exitcode }}"
-          echo "tf_stderr: ${{ steps.tf.outputs.stderr }}"
-          echo "tf_stdout: ${{ steps.tf.outputs.stdout }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -63,4 +63,6 @@ jobs:
           echo "identifier: ${{ steps.tf.outputs.identifier }}"
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
+          echo "stderr": ${{ steps.tf.outputs.stderr }}
+          echo "stdout": ${{ steps.tf.outputs.stdout }}
           echo "summary: ${{ steps.tf.outputs.summary }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -50,7 +50,6 @@ jobs:
           arg_command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           arg_lock: ${{ github.event.pull_request.merged && 'true' || 'false' }}
           arg_detailed_exitcode: true
-          plan_parity: true
           tf_tool: ${{ matrix.tool }}
           tf_version: ~> 1.8.0
 

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Provision TF
         id: tf
-        continue-on-error: true
+        # continue-on-error: true
         uses: ./
         with:
           arg_chdir: tests/${{ matrix.path }}

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Provision TF
         id: tf
-        # continue-on-error: true
+        continue-on-error: true
         uses: ./
         with:
           arg_chdir: tests/${{ matrix.path }}

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -65,5 +65,4 @@ jobs:
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
           echo "stderr: ${{ steps.tf.outputs.stderr }}"
-          echo "stdout: ${{ steps.tf.outputs.stdout }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,7 +54,6 @@ jobs:
           tf_version: ~> 1.8.0
 
       - name: Echo TF
-        continue-on-error: true
         run: |
           echo "check_id: ${{ steps.tf.outputs.check_id }}"
           echo "comment_id: ${{ steps.tf.outputs.comment_id }}"

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -63,3 +63,6 @@ jobs:
           echo "last_result: ${{ steps.tf.outputs.last_result }}"
           echo "outline: ${{ steps.tf.outputs.outline }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
+          echo "tf_exitcode: ${{ steps.tf.outputs.exitcode }}"
+          echo "tf_stderr: ${{ steps.tf.outputs.stderr }}"
+          echo "tf_stdout: ${{ steps.tf.outputs.stdout }}"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ In order to locally decrypt the TF plan file, use the following command (noting 
 | ------------- | ------------------------------------------------------- |
 | `check_id`    | String output of the workflow check run ID.             |
 | `comment_id`  | String output of the PR comment ID.                     |
-| `exitcode`    | String output of the last TF command's exitcode.        |
+| `exitcode`    | String output of the last TF command's exit code.       |
 | `fmt_result`  | String output of the TF fmt command.                    |
 | `header`      | String output of the TF command input.                  |
 | `identifier`  | String output of the TF run's unique identifier.        |

--- a/README.md
+++ b/README.md
@@ -177,16 +177,17 @@ In order to locally decrypt the TF plan file, use the following command (noting 
 
 ### Outputs
 
-| Name          | Description                                      |
-| ------------- | ------------------------------------------------ |
-| `check_id`    | String output of the workflow check run ID.      |
-| `comment_id`  | String output of the PR comment ID.              |
-| `fmt_result`  | String output of the TF fmt command.             |
-| `header`      | String output of the TF command input.           |
-| `identifier`  | String output of the TF run's unique identifier. |
-| `last_result` | String output of the last TF command.            |
-| `outline`     | String outline of the TF plan.                   |
-| `summary`     | String summary of the last TF command.           |
+| Name          | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `check_id`    | String output of the workflow check run ID.       |
+| `comment_id`  | String output of the PR comment ID.               |
+| `exitcode`    | String output of the last TF command's exitcode. |
+| `fmt_result`  | String output of the TF fmt command.              |
+| `header`      | String output of the TF command input.            |
+| `identifier`  | String output of the TF run's unique identifier.  |
+| `last_result` | String output of the last TF command.             |
+| `outline`     | String outline of the TF plan.                    |
+| `summary`     | String summary of the last TF command.            |
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -177,17 +177,19 @@ In order to locally decrypt the TF plan file, use the following command (noting 
 
 ### Outputs
 
-| Name          | Description                                       |
-| ------------- | ------------------------------------------------- |
-| `check_id`    | String output of the workflow check run ID.       |
-| `comment_id`  | String output of the PR comment ID.               |
-| `exitcode`    | String output of the last TF command's exitcode. |
-| `fmt_result`  | String output of the TF fmt command.              |
-| `header`      | String output of the TF command input.            |
-| `identifier`  | String output of the TF run's unique identifier.  |
-| `last_result` | String output of the last TF command.             |
-| `outline`     | String outline of the TF plan.                    |
-| `summary`     | String summary of the last TF command.            |
+| Name          | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `check_id`    | String output of the workflow check run ID.             |
+| `comment_id`  | String output of the PR comment ID.                     |
+| `exitcode`    | String output of the last TF command's exitcode.        |
+| `fmt_result`  | String output of the TF fmt command.                    |
+| `header`      | String output of the TF command input.                  |
+| `identifier`  | String output of the TF run's unique identifier.        |
+| `last_result` | String output of the last TF command.                   |
+| `outline`     | String outline of the TF plan.                          |
+| `stderr`      | String output of the last TF command's standard error.  |
+| `stdout`      | String output of the last TF command's standard output. |
+| `summary`     | String summary of the last TF command.                  |
 
 ## Security
 

--- a/action.js
+++ b/action.js
@@ -73,7 +73,7 @@ module.exports = async ({ context, core, exec, github }) => {
     core.setOutput("summary", result_summary);
   };
 
-  const listeners = {
+  const options = {
     listeners: {
       stdout: data_handler,
       stderr: data_handler,
@@ -87,7 +87,7 @@ module.exports = async ({ context, core, exec, github }) => {
     cli_input = header.concat(arguments.slice(input_header_slice)).join(" ");
     cli_result = "";
     core.setOutput("header", cli_input);
-    await exec.exec(process.env.tf_tool, arguments, listeners);
+    await exec.exec(process.env.tf_tool, arguments, options);
   };
 
   try {

--- a/action.js
+++ b/action.js
@@ -88,7 +88,9 @@ module.exports = async ({ context, core, exec, github }) => {
     cli_input = header.concat(arguments.slice(input_header_slice)).join(" ");
     cli_result = "";
     core.setOutput("header", cli_input);
-    await exec.exec(process.env.tf_tool, arguments, options);
+    const exitcode = await exec.exec(process.env.tf_tool, arguments, options);
+    // write code to output exitcode from the exec command
+    console.log("EXITCODE", exitcode.toString());
   };
 
   try {

--- a/action.js
+++ b/action.js
@@ -90,7 +90,7 @@ module.exports = async ({ context, core, exec, github }) => {
     core.setOutput("header", cli_input);
     const exitcode = await exec.exec(process.env.tf_tool, arguments, options);
     if (exitcode === 1) {
-      core.setFailed(`Failed with exit code ${exitcode}`);
+      core.setFailed(`Process failed with exit code ${exitcode}`);
     }
   };
 

--- a/action.js
+++ b/action.js
@@ -89,8 +89,9 @@ module.exports = async ({ context, core, exec, github }) => {
     cli_result = "";
     core.setOutput("header", cli_input);
     const exitcode = await exec.exec(process.env.tf_tool, arguments, options);
-    // write code to output exitcode from the exec command
-    console.log("EXITCODE", exitcode.toString());
+    if (exitcode === 1) {
+      core.setFailed(`Failed with exit code ${exitcode}`);
+    }
   };
 
   try {

--- a/action.js
+++ b/action.js
@@ -78,6 +78,7 @@ module.exports = async ({ context, core, exec, github }) => {
       stdout: data_handler,
       stderr: data_handler,
     },
+    ignoreReturnCode: true,
   };
 
   // Function to execute TF commands.

--- a/action.yml
+++ b/action.yml
@@ -238,7 +238,7 @@ outputs:
     description: String output of the last TF command's exit code.
     value: ${{ steps.tf.outputs.exitcode }}
   fmt_result:
-    description: String output of the TF fmt command.
+    description: String output of the TF fmt command (truncated).
     value: ${{ steps.tf.outputs.fmt_result }}
   header:
     description: String output of the TF command input.
@@ -247,11 +247,17 @@ outputs:
     description: String output of the TF run's unique identifier.
     value: ${{ steps.tf.outputs.identifier }}
   last_result:
-    description: String output of the last TF command.
+    description: String output of the last TF command (truncated).
     value: ${{ steps.tf.outputs.last_result }}
   outline:
     description: String outline of the TF plan.
     value: ${{ steps.tf.outputs.outline }}
+  stderr:
+    description: String output of the last TF command's standard error.
+    value: ${{ steps.tf.outputs.stderr }}
+  stdout:
+    description: String output of the last TF command's standard output.
+    value: ${{ steps.tf.outputs.stdout }}
   summary:
     description: String summary of the last TF command.
     value: ${{ steps.tf.outputs.summary }}

--- a/action.yml
+++ b/action.yml
@@ -252,6 +252,15 @@ outputs:
   summary:
     description: String summary of the last TF command.
     value: ${{ steps.tf.outputs.summary }}
+  exitcode:
+    description: String exit code of the TF command.
+    value: ${{ steps.tf.outputs.exitcode }}
+  stderr:
+    description: String standard error output of the TF command.
+    value: ${{ steps.tf.outputs.stderr }}
+  stdout:
+    description: String standard output of the TF command.
+    value: ${{ steps.tf.outputs.stdout }}
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -234,6 +234,9 @@ outputs:
   comment_id:
     description: String output of the PR comment ID.
     value: ${{ steps.tf.outputs.comment_id }}
+  exitcode:
+    description: String output of the last TF command's exit code.
+    value: ${{ steps.tf.outputs.exitcode }}
   fmt_result:
     description: String output of the TF fmt command.
     value: ${{ steps.tf.outputs.fmt_result }}
@@ -252,15 +255,6 @@ outputs:
   summary:
     description: String summary of the last TF command.
     value: ${{ steps.tf.outputs.summary }}
-  exitcode:
-    description: String exit code of the TF command.
-    value: ${{ steps.tf.outputs.exitcode }}
-  stderr:
-    description: String standard error output of the TF command.
-    value: ${{ steps.tf.outputs.stderr }}
-  stdout:
-    description: String standard output of the TF command.
-    value: ${{ steps.tf.outputs.stdout }}
 
 runs:
   using: composite


### PR DESCRIPTION
By default, the new `exitcode` [output parameter](https://github.com/DevSecTop/TF-via-PR?tab=readme-ov-file#outputs) will output `0` (succeeded) or `1` (failed).

By passing in `arg_detailed_exitcode: true`, then `exitcode` will return one of the [documented](https://opentofu.org/docs/cli/commands/plan/#other-options) exit codes:
- `0` = Succeeded with empty diff (no changes)
- `1` = Error
- `2` = Succeeded with non-empty diff (changes present)

Resolves #297.