### PR TITLE
feat: pass variables to `init`

### DIFF
--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -57,6 +57,7 @@ jobs:
           arg_backend_config: ${{ contains(matrix.dir, 'bucket') && format('backend/{0}.tfbackend', matrix.env) || '' }}
           arg_var_file: ${{ contains(matrix.dir, 'instance') && format('env/{0}.tfvars', matrix.env) || '' }}
           arg_workspace: ${{ matrix.env }}
+          arg_detailed_exitcode: true
           arg_or_create: true
           cache_plugins: true
           encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}

--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -43,14 +43,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: devsectop-tf-via-pr-${{ github.run_id }}-${{ github.run_attempt}}
 
-      # - name: Setup TF
-      #   uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
-      #   with:
-      #     tofu_version: ${{ env.TF_VERSION }}
       - name: Setup TF
-        uses: hashicorp/setup-terraform@v3
+        uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
         with:
-          terraform_version: ${{ env.TF_VERSION }}
+          tofu_version: ${{ env.TF_VERSION }}
 
       - name: Provision TF
         uses: ./
@@ -63,5 +59,5 @@ jobs:
           arg_workspace: ${{ matrix.env }}
           arg_detailed_exitcode: true
           arg_or_create: true
-          # cache_plugins: true
+          cache_plugins: true
           encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}

--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -63,5 +63,5 @@ jobs:
           arg_workspace: ${{ matrix.env }}
           arg_detailed_exitcode: true
           arg_or_create: true
-          cache_plugins: true
+          # cache_plugins: true
           encrypt_passphrase: ${{ secrets.TF_ENCRYPTION }}

--- a/.github/workflows/tf_sample.yaml
+++ b/.github/workflows/tf_sample.yaml
@@ -43,10 +43,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: devsectop-tf-via-pr-${{ github.run_id }}-${{ github.run_attempt}}
 
+      # - name: Setup TF
+      #   uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
+      #   with:
+      #     tofu_version: ${{ env.TF_VERSION }}
       - name: Setup TF
-        uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
+        uses: hashicorp/setup-terraform@v3
         with:
-          tofu_version: ${{ env.TF_VERSION }}
+          terraform_version: ${{ env.TF_VERSION }}
 
       - name: Provision TF
         uses: ./

--- a/action.js
+++ b/action.js
@@ -102,6 +102,8 @@ module.exports = async ({ context, core, exec, github }) => {
           process.env.arg_chdir,
           "init",
           process.env.arg_backend_config,
+          process.env.arg_var_file,
+          process.env.arg_var,
           process.env.arg_backend,
           process.env.arg_cloud,
           process.env.arg_force_copy,
@@ -120,7 +122,6 @@ module.exports = async ({ context, core, exec, github }) => {
           "init",
           process.env.arg_chdir,
           process.env.arg_workspace_alt,
-          process.env.arg_var_file,
           process.env.arg_destroy,
         ],
         2

--- a/sample/instance/providers.tf
+++ b/sample/instance/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8.0"
 
   backend "s3" {
     bucket = "tmp-workflow-tfstates"


### PR DESCRIPTION
Since OpenTofu supports -var-file and -var input to [`init` command](https://opentofu.org/docs/cli/commands/init/#general-options) as part of their early (static) evaluation of variables/inputs.