### PR TITLE
remove: pr label functionality

### DIFF
--- a/.github/examples/pr_manual_label.yaml
+++ b/.github/examples/pr_manual_label.yaml
@@ -27,7 +27,7 @@ jobs:
       actions: read        # Required to identify workflow run.
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     steps:
       - name: Checkout repository

--- a/.github/examples/pr_merge_matrix.yaml
+++ b/.github/examples/pr_merge_matrix.yaml
@@ -13,7 +13,7 @@ jobs:
       actions: read        # Required to identify workflow run.
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     strategy:
       fail-fast: false

--- a/.github/examples/pr_push_auth.yaml
+++ b/.github/examples/pr_push_auth.yaml
@@ -15,7 +15,7 @@ jobs:
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
       id-token: write      # Required to authenticate via OIDC.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     steps:
       - name: Checkout repository

--- a/.github/examples/pr_push_lint.yaml
+++ b/.github/examples/pr_push_lint.yaml
@@ -14,7 +14,7 @@ jobs:
       actions: read        # Required to identify workflow run.
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     steps:
       - name: Checkout repository

--- a/.github/examples/pr_push_stages.yaml
+++ b/.github/examples/pr_push_stages.yaml
@@ -10,7 +10,7 @@ permissions:
   actions: read        # Required to identify workflow run.
   checks: write        # Required to add status summary.
   contents: read       # Required to checkout repository.
-  pull-requests: write # Required to add comment and label.
+  pull-requests: write # Required to add PR comment.
 
 jobs:
   plan:

--- a/.github/examples/schedule_refresh.yaml
+++ b/.github/examples/schedule_refresh.yaml
@@ -14,7 +14,7 @@ jobs:
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
       issues: write        # Required to open issue.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -14,7 +14,7 @@ jobs:
       actions: read # Required to identify workflow run.
       checks: write # Required to add status summary.
       contents: read # Required to checkout repository.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
       actions: read        # Required to identify workflow run.
       checks: write        # Required to add status summary.
       contents: read       # Required to checkout repository.
-      pull-requests: write # Required to add comment and label.
+      pull-requests: write # Required to add PR comment.
 
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +172,6 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
 | UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                                 |
 | UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                              |
-| UI       | `label-pr`          | Add a PR label with the command input (e.g., `tf:plan`).</br>Default: `true`                                                              |
 | UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                                    |
 | UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |
 | UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                   |

--- a/action.yml
+++ b/action.yml
@@ -158,13 +158,6 @@ runs:
         echo "${{ inputs.tool }} validate${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
         ${{ inputs.tool }}${{ steps.arg.outputs.arg-chdir }} validate${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
 
-    - if: ${{ inputs.label-pr == 'true' && steps.identifier.outputs.pr != 0 && contains(fromJSON('["plan", "apply"]'), inputs.command) }}
-      continue-on-error: true
-      shell: bash
-      run: |
-        # Label PR.
-        gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/labels --header "$GH_API" --method POST --silent --field "labels[]=tf:${{ inputs.command }}"
-
     - if: ${{ inputs.command == 'plan' }}
       id: plan
       env:
@@ -518,10 +511,6 @@ inputs:
   hide-args:
     default: "detailed-exitcode,parallelism,lock,out,var="
     description: "Hide comma-separated arguments from the command input (e.g., `detailed-exitcode,lock,out,var=`)."
-    required: false
-  label-pr:
-    default: "true"
-    description: "Add a PR label with the command input (e.g., `true`)."
     required: false
   plan-encrypt:
     default: ""


### PR DESCRIPTION
### Removed

- The `label-pr` option used to create and attach `tf:plan` or `tf:apply` PR labels using the `pull-requests: write` permission, until GitHub made an [un-announced](https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2780292262) and [un-documented](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#create-a-label) change to require `issues: write` as well.
  Frankly, I think it's a lot to ask of users to trust their infrastructure provisioning to a 3rd party GitHub Action, so every effort is made to reduce TF-via-PR's access footprint and permission scope. To return this behaviour, add the following line to your workflow along with `issues: write` permission.

    ```
    run: gh api /repos/${{ github.repository }}/issues/${{ github.event.number || github.event.issue.number }}/labels --field "labels[]=tf:${{ github.event_name == 'push' && 'apply' || 'plan' }}"
    ```


Fixes #460.