### PR TITLE
doc: todo provisioning of interim build artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ View [all notable changes](https://github.com/op5dev/tf-via-pr/releases "Release
 
 - Handling of inputs which contain space(s) (e.g., `working-directory: path to/directory`).
 - Handling of comma-separated inputs which contain comma(s) (e.g., `arg-var: token=1,2,3`); workaround with `TF_CLI_ARGS` [environment variable](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_cli_args-and-tf_cli_args_name).
-- Handling of interim build artifact(s) between `plan` and `apply` commands (e.g., zip archive); workaround with `arg-auto-approve: true` so that `apply` rebuilds artifact(s) for provisioning ([discussion](https://github.com/OP5dev/TF-via-PR/issues/517)).
+- Handling of interim build artifact(s) between `plan` and `apply` commands (e.g., zip archive); workaround with `arg-auto-approve: true` so that `apply` rebuilds artifact(s) for provisioning ([join discussion](https://github.com/OP5dev/TF-via-PR/issues/517)).
 
 </br>
 


### PR DESCRIPTION
Following #517, document the lack of support for provisioning interim build artifacts with a (sub-standard) workaround to add `arg-auto-approve: true` during `apply`.

Thanks for identifying this gap, @slords.