### PR TITLE
fix: correct non-existent directory reference in test script

### DIFF
--- a/tests/tf.sh
+++ b/tests/tf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 terraform -chdir=tests/pass_one init -no-color 2> >(tee pass_one.txt) > >(tee pass_one.txt)
-terraform -chdir=tests/pass_format_diff fmt -check=true -diff=true -no-color 2> >(tee pass_format_diff.txt) > >(tee pass_format_diff.txt)
+terraform -chdir=tests/fail_format_diff fmt -check=true -diff=true -no-color 2> >(tee fail_format_diff.txt) > >(tee fail_format_diff.txt)
 terraform -chdir=tests/fail_data_source_error init -no-color 2> >(tee fail_data_source_error.txt) > >(tee fail_data_source_error.txt)
 terraform -chdir=tests/fail_invalid_resource_type init -no-color 2> >(tee fail_invalid_resource_type.txt) > >(tee fail_invalid_resource_type.txt)


### PR DESCRIPTION
The test script referenced `tests/pass_format_diff` which does not exist. Changed to `tests/fail_format_diff` to match the actual directory structure.