### PR TITLE
fix: pass github.token to when making the check-run api call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -398,7 +398,7 @@ runs:
         echo "job=$job_id" >> "$GITHUB_OUTPUT"
 
         # Add summary to the job status.
-        check_run=$(gh api /repos/${{ github.repository }}/check-runs/${job_id} --header "$GH_API" --method PATCH --field "output[title]=${summary}" --field "output[summary]=${summary}")
+        check_run=$(GH_TOKEN=${{ github.token }} gh api /repos/${{ github.repository }}/check-runs/${job_id} --header "$GH_API" --method PATCH --field "output[title]=${summary}" --field "output[summary]=${summary}")
 
         # Get the step number that has status "in_progress" from the current job.
         workflow_step=$(echo "$workflow_run" | jq --raw-output --arg job_id "$job_id" '.jobs[] | select(.id == ($job_id | tonumber)) | .steps[] | select(.status == "in_progress") | .number')


### PR DESCRIPTION
closes #538 

wasn't sure if GH_TOKEN will be shown as plain text, but it appears it's not
<img width="356" height="61" alt="image" src="https://github.com/user-attachments/assets/480766d3-5656-4513-8e26-371db56c0498" />

happy to make adjustments if you have another idea to try