### PR TITLE
feat(comment): optionally disable comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
 | UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                                 |
 | UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                              |
-| UI       | `comment-pr`        | Add a PR comment: `always`, `on-diff`, or `never`.<sup>4</sup></br>Default: `always`                                                      |
-| UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |
-| UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-diff`, or `never`.<sup>4</sup></br>Default: `always`                                     |
-| UI       | `hide-args`         | Hide comma-separated list of CLI arguments from the command input.<sup>6</sup></br>Default: `detailed-exitcode,parallelism,lock,out,var=` |
-| UI       | `show-args`         | Show comma-separated list of CLI arguments in the command input.<sup>6</sup></br>Default: `workspace`                                     |
+| UI       | `post-comment`      | Post or update the PR comment from this action; disable to use `comment-body` output without writing a PR comment.<sup>4</sup></br>Default: `true` |
+| UI       | `comment-pr`        | Add a PR comment: `always`, `on-diff`, or `never`.<sup>5</sup></br>Default: `always`                                                      |
+| UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>6</sup></br>Default: `update`                         |
+| UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-diff`, or `never`.<sup>5</sup></br>Default: `always`                                     |
+| UI       | `hide-args`         | Hide comma-separated list of CLI arguments from the command input.<sup>7</sup></br>Default: `detailed-exitcode,parallelism,lock,out,var=` |
+| UI       | `show-args`         | Show comma-separated list of CLI arguments in the command input.<sup>7</sup></br>Default: `workspace`                                     |
 
 </br>
 
@@ -196,6 +197,7 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
     To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
 1. Originally intended for `merge_group` event trigger, `plan-parity: true` input helps to prevent stale apply within a series of workflow runs when merging multiple PRs.</br></br>
 1. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
+1. Set `post-comment: false` to skip creating or updating a PR comment while still exposing the rendered comment body through the `comment-body` output, which is useful for custom matrix aggregation or externally managed PR comments.</br></br>
 1. The `on-diff` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
 1. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
   [![PR comment revision history comparing plan and apply outputs.](/.github/assets/revisions.png)](https://raw.githubusercontent.com/op5dev/tf-via-pr/refs/heads/main/.github/assets/revisions.png "View full-size image.")</br></br>

--- a/action.yml
+++ b/action.yml
@@ -325,6 +325,7 @@ runs:
         GH_MATRIX: ${{ toJSON(matrix) }}
         INPUTS_COMMAND: ${{ inputs.command }}
         INPUTS_COMMENT_METHOD: ${{ inputs.comment-method }}
+        INPUTS_POST_COMMENT: ${{ inputs.post-comment }}
         INPUTS_COMMENT_PR: ${{ inputs.comment-pr }}
         INPUTS_EXPAND_DIFF: ${{ inputs.expand-diff }}
         INPUTS_EXPAND_SUMMARY: ${{ inputs.expand-summary }}
@@ -482,6 +483,11 @@ runs:
           exit 0
         fi
 
+        # Exit early if PR comment posting is disabled.
+        if [[ "$INPUTS_POST_COMMENT" != "true" ]]; then
+          exit 0
+        fi
+
         # Check if the PR contains a bot comment with the same identifier.
         list_comments=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --paginate)
         bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
@@ -603,6 +609,10 @@ inputs:
   plan-parity:
     default: "false"
     description: "Replace the plan file if it matches a newly-generated one to prevent stale apply (e.g., `false`)."
+    required: false
+  post-comment:
+    default: "true"
+    description: "Post or update the PR comment from this action. Disable to use `comment-body` output without writing a PR comment (e.g., `true`)."
     required: false
   pr-number:
     default: ""


### PR DESCRIPTION
This action currently attempts to overwrite / recreate any previous comments. While this approach is useful for most setups, it leads to race conditions when this actions is being used in a matrix - where one job overwrites the comment of a previous job.

This PR introduces a new boolean argument `post-comment` that if disabled, skips posting the TF diff comment. 
Users can then instead use the output of the action and implement their own commenting logic:

This approach could also be used to allow posting all diffs in one comment (https://github.com/OP5dev/TF-via-PR/issues/535):


Example: 
```yaml
jobs:
  tf-plan:
    strategy:
      fail-fast: false
      matrix:
        include:
          - cluster: dev
            account_id: "1234"
          - cluster: prod
            account_id: "56789"
  steps:
      - id: terraform-plan
        uses: op5dev/tf-via-pr@v13
        with:
          working-directory: infra
          post-comment: false

      - name: Post Terraform plan comment
        env:
          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
          COMMENT_BODY: ${{ steps.terraform-plan.outputs.comment-body }}
          COMMENT_TITLE: ${{ github.workflow }} / ${{ matrix.cluster }}
        run: |
          comment_file="$(mktemp)"
          printf '## %s\n\n%s\n' \
            "${COMMENT_TITLE}" \
            "${COMMENT_BODY}" > "${comment_file}"

          gh pr comment "${{ github.event.number }}" \
            --repo "${{ github.repository }}" \
            --body-file "${comment_file}"
```

result: 

```
Terraform Infrastructure CI / prod

terraform plan -chdir=infra -var-file=vars/default.tfvars -var-file=clusters/prod.tfvars
Diff of 3 changes.
Plan: 0 to add, 3 to change, 0 to destroy.
By @FalcoSuessgott at 2026-03-24T05:19:41Z.
```

```
Terraform Infrastructure CI / dev

terraform plan -chdir=infra -var-file=vars/default.tfvars -var-file=clusters/dev.tfvars
Diff of 4 changes.
Plan: 0 to add, 4 to change, 0 to destroy.
By @FalcoSuessgott at 2026-03-24T05:19:41Z .
````