### PR TITLE
fix: replace dual process substitution with single pipe for output capture

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
         trap 'exit_code="$?"; echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"' EXIT
         args="${{ steps.arg.outputs.arg-check }}${{ steps.arg.outputs.arg-diff }}${{ steps.arg.outputs.arg-list }}${{ steps.arg.outputs.arg-recursive }}${{ steps.arg.outputs.arg-write }}"
         echo "$INPUTS_TOOL fmt${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
-        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} fmt${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
+        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} fmt${args} 2>&1 | tee tf.console.txt
 
     - if: ${{ contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       id: initialize
@@ -163,7 +163,7 @@ runs:
         trap 'exit_code="$?"; echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"' EXIT
         args="${{ steps.arg.outputs.arg-backend-config }}${{ steps.arg.outputs.arg-backend }}${{ env.INPUTS_TOOL == 'tofu' && steps.arg.outputs.arg-var-file || '' }}${{ env.INPUTS_TOOL == 'tofu' && steps.arg.outputs.arg-var || '' }}${{ steps.arg.outputs.arg-force-copy }}${{ steps.arg.outputs.arg-from-module }}${{ steps.arg.outputs.arg-get }}${{ steps.arg.outputs.arg-lock-timeout }}${{ steps.arg.outputs.arg-lock }}${{ steps.arg.outputs.arg-lockfile }}${{ steps.arg.outputs.arg-migrate-state }}${{ steps.arg.outputs.arg-plugin-dir }}${{ steps.arg.outputs.arg-reconfigure }}${{ steps.arg.outputs.arg-test-directory }}${{ steps.arg.outputs.arg-upgrade }}"
         echo "$INPUTS_TOOL init${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
-        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} init${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
+        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} init${args} 2>&1 | tee tf.console.txt
 
     - if: ${{ inputs.validate == 'true' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       id: validate
@@ -175,7 +175,7 @@ runs:
         trap 'exit_code="$?"; echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"' EXIT
         args="${{ env.INPUTS_TOOL == 'tofu' && steps.arg.outputs.arg-var-file || '' }}${{ env.INPUTS_TOOL == 'tofu' && steps.arg.outputs.arg-var || '' }}${{ steps.arg.outputs.arg-no-tests }}${{ steps.arg.outputs.arg-test-directory }}"
         echo "$INPUTS_TOOL validate${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
-        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} validate${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
+        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} validate${args} 2>&1 | tee tf.console.txt
 
     - if: ${{ inputs.command == 'plan' }}
       id: plan
@@ -190,7 +190,7 @@ runs:
         args="${{ steps.arg.outputs.arg-destroy }}${{ steps.arg.outputs.arg-var-file }}${{ steps.arg.outputs.arg-var }}${{ steps.arg.outputs.arg-compact-warnings }}${{ steps.arg.outputs.arg-concise }}${{ steps.arg.outputs.arg-detailed-exitcode }}${{ steps.arg.outputs.arg-generate-config-out }}${{ steps.arg.outputs.arg-lock-timeout }}${{ steps.arg.outputs.arg-lock }}${{ steps.arg.outputs.arg-parallelism }}${{ steps.arg.outputs.arg-refresh-only }}${{ steps.arg.outputs.arg-refresh }}${{ steps.arg.outputs.arg-replace }}${{ steps.arg.outputs.arg-target }} -out=tfplan"
         echo "$INPUTS_TOOL plan${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
         if [[ -n "$INPUTS_PLAN_FILE" ]]; then mv --force --verbose "$INPUTS_PLAN_FILE" "$path" 2>/dev/null && exit 0; fi
-        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} plan${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
+        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} plan${args} 2>&1 | tee tf.console.txt
 
     - if: ${{ inputs.command == 'apply' && inputs.arg-auto-approve != 'true' && inputs.plan-file == '' }}
       id: download
@@ -316,7 +316,7 @@ runs:
         fi
         args="${{ steps.arg.outputs.arg-destroy }}${var_file}${var}${{ steps.arg.outputs.arg-backup }}${{ steps.arg.outputs.arg-compact-warnings }}${{ steps.arg.outputs.arg-concise }}${{ steps.arg.outputs.arg-lock-timeout }}${{ steps.arg.outputs.arg-lock }}${{ steps.arg.outputs.arg-parallelism }}${{ steps.arg.outputs.arg-refresh-only }}${{ steps.arg.outputs.arg-refresh }}${{ steps.arg.outputs.arg-replace }}${{ steps.arg.outputs.arg-state-out }}${{ steps.arg.outputs.arg-state }}${{ steps.arg.outputs.arg-target }}${plan}"
         echo "$INPUTS_TOOL apply${{ steps.arg.outputs.arg-chdir }}${args}" | sed 's/ -/\n -/g' > tf.command.txt
-        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} apply${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
+        $INPUTS_TOOL${{ steps.arg.outputs.arg-chdir }} apply${args} 2>&1 | tee tf.console.txt
 
     - if: ${{ !cancelled() && steps.identifier.outcome == 'success' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       id: post


### PR DESCRIPTION
## Problem

The current output capture pattern uses two process substitutions writing to the same file:

```bash
terraform plan ... 2> >(tee tf.console.txt) > >(tee tf.console.txt)
```

This creates two independent `tee` processes that both open `tf.console.txt` for writing (truncating). Whichever process opens the file last truncates the other's output. This is a race condition — the result depends on OS-level process scheduling, and it intermittently produces empty or corrupted `tf.console.txt` files.

When `tf.console.txt` is empty, the summary extraction defaults to "View output." with an empty PR comment body:

```bash
summary=$(awk '/^(Error:|Plan:|Apply complete!|No changes.|Success)/ ...' tf.console.txt)
# empty file → "View output."
```

## Fix

Replace all 5 occurrences with a single pipe:

```bash
terraform plan ... 2>&1 | tee tf.console.txt
```

This merges stderr into stdout and pipes through a single `tee` process — no race, no file truncation. Exit codes are preserved correctly because GitHub Actions runs bash with `-o pipefail` by default.

## How we discovered this

We run `tf-via-pr` inside Alpine containers on ARC (Actions Runner Controller) Kubernetes runners in a matrix strategy across 7 AWS regions. In our test runs, some regions produced full plan output while others consistently showed "View output." with empty comment bodies — despite terraform plan completing successfully (exit code 2, changes detected).

The CI logs confirmed the root cause — a `null byte in input` warning from bash during the post-processing command substitution, indicating corrupted interleaved writes to `tf.console.txt`:

```
/__w/_temp/ec67bbac-....sh: line 23: warning: command substitution: ignored null byte in input
```

## Testing

We tested the fix across two environments with different runner configurations:

| Environment | Runner type | Jobs | Plan comments | Empty outputs |
|-------------|------------|------|--------------|---------------|
| AWS infra repo (ARC K8s, Alpine container) | Self-hosted ARC + `container: node:lts-alpine` | 7 | 7 | 0 |
| GCP infra repo (ARC K8s, no container) | Self-hosted ARC | 139 | 139 | 0 |

The GCP test modified a shared Terraform module referenced by 139 root modules — every plan comment showed "Diff of 1 change." with full output. Zero empty comments across both environments.

**Before the fix** (same 7-region matrix on ARC):
- Region A: "View output." — 495 chars, empty body
- Region B: "View output." — 495 chars, empty body
- Region C: "Diff of 255 changes." — 66K chars (race condition happened to preserve stdout)

**After the fix:**
- Region A: "Diff of 170 changes." — 66K chars
- Region B: "Diff of 85 changes." — 53K chars
- Region C: "Diff of 255 changes." — 66K chars

## Notes

- This is a one-line change in 5 places (`action.yml` only)
- The `2>&1` merge means stderr and stdout are interleaved in the output file rather than separated, but the prior pattern also wrote both to the same file — so the observable behavior is unchanged
- No change in exit code handling — `pipefail` (enabled by default in GHA's bash shell) preserves terraform's exit code through the pipe