### PR TITLE
fix: enhance PR number retrieval logic for various event types including fork branches

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,7 @@ runs:
       env:
         INPUTS_PR_NUMBER: ${{ inputs.pr-number }}
         INPUTS_TOOL: ${{ inputs.tool }}
+        WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       shell: bash
       run: |
         # Unique identifier.
@@ -125,14 +126,18 @@ runs:
           pr_number="$INPUTS_PR_NUMBER"
         elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "repository_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_call" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
           # List PRs associated with the commit, then get the PR number from the head ref or the latest PR.
-          associated_prs=$(gh api /repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha || github.sha }}/pulls --header "$GH_API" --method GET --paginate)
-          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME) | .number) // .[0].number // 0')
+          associated_prs=$(gh api /repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}/pulls --header "$GH_API" --method GET --paginate)
+          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME or .head.ref == env.WORKFLOW_RUN_HEAD_BRANCH) | .number) // .[0].number // 0')
         elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
           # Get the PR number by parsing the ref name.
           pr_number=$(echo "${{ github.ref_name }}" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')
         else
-          # Get the PR number from branch name, otherwise fallback on 0 if the PR number is not found.
-          pr_number=${{ github.event.number || github.event.issue.number }} || $(gh api /repos/${{ github.repository }}/pulls --header "$GH_API" --method GET --paginate --field head="${{ github.ref_name || github.head_ref || github.ref || '0' }}" | jq '.[0].number // 0')
+          # Get the PR number from the event or issue if available; otherwise, look it up by head ref and fallback on 0 if not found.
+          if [[ -n "${{ github.event.number || github.event.issue.number }}" ]]; then
+            pr_number=${{ github.event.number || github.event.issue.number }}
+          else
+            pr_number=$(gh api /repos/${{ github.repository }}/pulls --header "$GH_API" --method GET --paginate --field head="${{ github.event.pull_request.head.label || github.ref_name || github.head_ref || github.ref || '0' }}" | jq '.[0].number // 0')
+          fi
         fi
         echo "pr=${pr_number:-0}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This pull request updates the logic for determining the pull request number in the `action.yml` workflow, improving its accuracy and robustness for various GitHub event types. The main changes enhance how the workflow identifies the correct PR number, especially for `workflow_run` events and when information is missing from the event payload.

**Improvements to PR number detection:**

* Added the `WORKFLOW_RUN_HEAD_BRANCH` environment variable to help resolve the correct PR branch for `workflow_run` events.
* Enhanced the logic to use `github.event.workflow_run.head_sha` as a fallback when looking up associated PRs, ensuring better coverage for different event types.
* Updated the PR number selection to match either `GITHUB_REF_NAME` or the new `WORKFLOW_RUN_HEAD_BRANCH`, improving accuracy for workflow runs triggered by PRs.

**Fallback and error handling improvements:**

* Improved fallback logic to explicitly check for the presence of `github.event.number` or `github.event.issue.number` before querying for the PR by head ref, reducing the chance of errors when these values are missing.
* Refined the head ref lookup to include `github.event.pull_request.head.label` as an additional fallback, increasing robustness in edge cases.