### PR TITLE
fix: address CodeQL expression injection via environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,8 +132,7 @@ runs:
         elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "repository_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_call" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
           # List PRs associated with the commit, then get the PR number from the head ref or the latest PR.
           associated_prs=$(gh api /repos/$GH_REPO/commits/$GH_COMMIT_SHA/pulls --header "$GH_API" --method GET --paginate)
-          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME or .head.ref ==
-          .GH_WORKFLOW_RUN_HEAD_BRANCH) | .number) // .[0].number // 0')
+          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME or .head.ref == env.GH_WORKFLOW_RUN_HEAD_BRANCH) | .number) // .[0].number // 0')
         elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
           # Get the PR number by parsing the ref name.
           pr_number=$(echo "$GITHUB_REF_NAME" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         # Populate variables.
         # Environment variables.
         echo "GH_API=X-GitHub-Api-Version:2022-11-28" >> "$GITHUB_ENV"
-        echo "GH_HOST=$(echo $GITHUB_SERVER_URL | sed 's/.*:\/\///')" >> "$GITHUB_ENV"
+        echo "GH_HOST=${GITHUB_SERVER_URL#*://}" >> "$GITHUB_ENV"
         echo "GH_REPO=$GH_REPO" >> "$GITHUB_ENV"
         echo "GH_TOKEN=$INPUTS_TOKEN" >> "$GITHUB_ENV"
         echo "TF_CLI_ARGS=$([[ -n "${{ env.TF_CLI_ARGS }}" ]] && echo "${{ env.TF_CLI_ARGS }} -no-color" || echo "-no-color")" >> "$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ runs:
 
     - id: arg
       env:
+        GH_REPO: ${{ github.repository }}
         INPUTS_ARG_AUTO_APPROVE: ${{ inputs.arg-auto-approve }}
         INPUTS_ARG_BACKEND_CONFIG: ${{ inputs.arg-backend-config }}
         INPUTS_ARG_BACKEND: ${{ inputs.arg-backend }}
@@ -66,12 +67,13 @@ runs:
         # Populate variables.
         # Environment variables.
         echo "GH_API=X-GitHub-Api-Version:2022-11-28" >> "$GITHUB_ENV"
+        echo "GH_HOST=$(echo $GITHUB_SERVER_URL | sed 's/.*:\/\///')" >> "$GITHUB_ENV"
+        echo "GH_REPO=$GH_REPO" >> "$GITHUB_ENV"
         echo "GH_TOKEN=$INPUTS_TOKEN" >> "$GITHUB_ENV"
         echo "TF_CLI_ARGS=$([[ -n "${{ env.TF_CLI_ARGS }}" ]] && echo "${{ env.TF_CLI_ARGS }} -no-color" || echo "-no-color")" >> "$GITHUB_ENV"
         echo "TF_IN_AUTOMATION=true" >> "$GITHUB_ENV"
         echo "TF_INPUT=false" >> "$GITHUB_ENV"
         echo "TF_WORKSPACE=$TF_WORKSPACE" >> "$GITHUB_ENV"
-        echo "GH_HOST=$(echo $GITHUB_SERVER_URL | sed 's/.*:\/\///')" >> "$GITHUB_ENV"
 
         # CLI arguments.
         echo arg-auto-approve=$([[ "${INPUTS_ARG_AUTO_APPROVE,,}" == "true" ]] && echo " -auto-approve" || echo "") >> "$GITHUB_OUTPUT"
@@ -117,7 +119,6 @@ runs:
         GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
         GH_EVENT_NUMBER: ${{ github.event.number || github.event.issue.number }}
         GH_HEAD_REF: ${{ github.event.pull_request.head.label || github.ref_name || github.head_ref || github.ref || '0' }}
-        GH_REPO: ${{ github.repository }}
         GH_WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         INPUTS_PR_NUMBER: ${{ inputs.pr-number }}
         INPUTS_TOOL: ${{ inputs.tool }}
@@ -149,6 +150,7 @@ runs:
         # Generate identifier for the workflow run using MD5 hashing algorithm for concise and unique naming.
         identifier="${{ steps.arg.outputs.arg-chdir }}${{ steps.arg.outputs.arg-workspace }}${{ steps.arg.outputs.arg-backend-config }}${{ steps.arg.outputs.arg-var-file }}${{ steps.arg.outputs.arg-var }}${{ steps.arg.outputs.arg-replace }}${{ steps.arg.outputs.arg-target }}${{ steps.arg.outputs.arg-destroy }}"
         identifier=$(echo -n "$identifier" | md5sum | awk '{print $1}')
+        echo "GH_IDENTIFIER_NAME=${INPUTS_TOOL}-${pr_number}-${identifier}.tfplan" >> "$GITHUB_ENV"
         echo "name=${INPUTS_TOOL}-${pr_number}-${identifier}.tfplan" >> "$GITHUB_OUTPUT"
 
     - if: ${{ inputs.format == 'true' }}
@@ -205,8 +207,6 @@ runs:
     - if: ${{ inputs.command == 'apply' && inputs.arg-auto-approve != 'true' && inputs.plan-file == '' }}
       id: download
       env:
-        GH_IDENTIFIER_NAME: ${{ steps.identifier.outputs.name }}
-        GH_REPO: ${{ github.repository }}
         INPUTS_ARG_CHDIR: ${{ inputs.arg-chdir || inputs.working-directory }}
       shell: bash
       run: |
@@ -335,10 +335,8 @@ runs:
       env:
         GH_ACTIONS_TOKEN: ${{ github.token }}
         GH_EVENT_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }}
-        GH_IDENTIFIER_NAME: ${{ steps.identifier.outputs.name }}
         GH_MATRIX: ${{ toJSON(matrix) }}
         GH_PR_NUMBER: ${{ steps.identifier.outputs.pr }}
-        GH_REPO: ${{ github.repository }}
         GH_RUN_ATTEMPT: ${{ github.run_attempt }}
         GH_RUN_ID: ${{ github.run_id }}
         GH_SERVER_URL: ${{ github.server_url }}

--- a/action.yml
+++ b/action.yml
@@ -114,9 +114,13 @@ runs:
 
     - id: identifier
       env:
+        GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+        GH_EVENT_NUMBER: ${{ github.event.number || github.event.issue.number }}
+        GH_HEAD_REF: ${{ github.event.pull_request.head.label || github.ref_name || github.head_ref || github.ref || '0' }}
+        GH_REPO: ${{ github.repository }}
+        GH_WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         INPUTS_PR_NUMBER: ${{ inputs.pr-number }}
         INPUTS_TOOL: ${{ inputs.tool }}
-        WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       shell: bash
       run: |
         # Unique identifier.
@@ -126,17 +130,18 @@ runs:
           pr_number="$INPUTS_PR_NUMBER"
         elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "repository_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_call" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
           # List PRs associated with the commit, then get the PR number from the head ref or the latest PR.
-          associated_prs=$(gh api /repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}/pulls --header "$GH_API" --method GET --paginate)
-          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME or .head.ref == env.WORKFLOW_RUN_HEAD_BRANCH) | .number) // .[0].number // 0')
+          associated_prs=$(gh api /repos/$GH_REPO/commits/$GH_COMMIT_SHA/pulls --header "$GH_API" --method GET --paginate)
+          pr_number=$(echo "$associated_prs" | jq --raw-output '(.[] | select(.head.ref == env.GITHUB_REF_NAME or .head.ref ==
+          .GH_WORKFLOW_RUN_HEAD_BRANCH) | .number) // .[0].number // 0')
         elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
           # Get the PR number by parsing the ref name.
-          pr_number=$(echo "${{ github.ref_name }}" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')
+          pr_number=$(echo "$GITHUB_REF_NAME" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')
         else
           # Get the PR number from the event or issue if available; otherwise, look it up by head ref and fallback on 0 if not found.
-          if [[ -n "${{ github.event.number || github.event.issue.number }}" ]]; then
-            pr_number=${{ github.event.number || github.event.issue.number }}
+          if [[ -n "$GH_EVENT_NUMBER" ]]; then
+            pr_number="$GH_EVENT_NUMBER"
           else
-            pr_number=$(gh api /repos/${{ github.repository }}/pulls --header "$GH_API" --method GET --paginate --field head="${{ github.event.pull_request.head.label || github.ref_name || github.head_ref || github.ref || '0' }}" | jq '.[0].number // 0')
+            pr_number=$(gh api /repos/$GH_REPO/pulls --header "$GH_API" --method GET --paginate --field head="$GH_HEAD_REF" | jq '.[0].number // 0')
           fi
         fi
         echo "pr=${pr_number:-0}" >> "$GITHUB_OUTPUT"
@@ -200,18 +205,20 @@ runs:
     - if: ${{ inputs.command == 'apply' && inputs.arg-auto-approve != 'true' && inputs.plan-file == '' }}
       id: download
       env:
+        GH_IDENTIFIER_NAME: ${{ steps.identifier.outputs.name }}
+        GH_REPO: ${{ github.repository }}
         INPUTS_ARG_CHDIR: ${{ inputs.arg-chdir || inputs.working-directory }}
       shell: bash
       run: |
         # Download plan file.
         # Get the artifact ID of the latest matching plan files for download.
-        artifact_id=$(gh api /repos/${{ github.repository }}/actions/artifacts --header "$GH_API" --method GET --field "name=${{ steps.identifier.outputs.name }}" --jq '.artifacts[0].id' 2>/dev/null)
-        if [[ -z "$artifact_id" ]]; then echo "Unable to locate plan file: ${{ steps.identifier.outputs.name }}." && exit 1; fi
-        gh api /repos/${{ github.repository }}/actions/artifacts/${artifact_id}/zip --header "$GH_API" --method GET > "${{ steps.identifier.outputs.name }}.zip"
+        artifact_id=$(gh api /repos/$GH_REPO/actions/artifacts --header "$GH_API" --method GET --field "name=$GH_IDENTIFIER_NAME" --jq '.artifacts[0].id' 2>/dev/null)
+        if [[ -z "$artifact_id" ]]; then echo "Unable to locate plan file: $GH_IDENTIFIER_NAME." && exit 1; fi
+        gh api /repos/$GH_REPO/actions/artifacts/${artifact_id}/zip --header "$GH_API" --method GET > "$GH_IDENTIFIER_NAME.zip"
 
         # Unzip the plan file to the working directory, then clean up the zip file.
-        unzip "${{ steps.identifier.outputs.name }}.zip" -d "$INPUTS_ARG_CHDIR"
-        rm --force "${{ steps.identifier.outputs.name }}.zip"
+        unzip "$GH_IDENTIFIER_NAME.zip" -d "$INPUTS_ARG_CHDIR"
+        rm --force "$GH_IDENTIFIER_NAME.zip"
 
     - if: ${{ inputs.plan-encrypt != '' && steps.download.outcome == 'success' }}
       env:
@@ -326,8 +333,16 @@ runs:
     - if: ${{ !cancelled() && steps.identifier.outcome == 'success' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       id: post
       env:
-        exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
+        GH_ACTIONS_TOKEN: ${{ github.token }}
+        GH_EVENT_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }}
+        GH_IDENTIFIER_NAME: ${{ steps.identifier.outputs.name }}
         GH_MATRIX: ${{ toJSON(matrix) }}
+        GH_PR_NUMBER: ${{ steps.identifier.outputs.pr }}
+        GH_REPO: ${{ github.repository }}
+        GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GH_RUN_ID: ${{ github.run_id }}
+        GH_SERVER_URL: ${{ github.server_url }}
+        GH_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         INPUTS_COMMAND: ${{ inputs.command }}
         INPUTS_COMMENT_METHOD: ${{ inputs.comment-method }}
         INPUTS_COMMENT_PR: ${{ inputs.comment-pr }}
@@ -337,6 +352,7 @@ runs:
         INPUTS_PRESERVE_PLAN: ${{ inputs.preserve-plan }}
         INPUTS_SHOW_ARGS: ${{ inputs.show-args }}
         INPUTS_TAG_ACTOR: ${{ inputs.tag-actor }}
+        exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
         path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
       shell: bash
       run: |
@@ -375,7 +391,7 @@ runs:
         if [[ "${{ steps.format.outcome }}" == "failure" ]]; then syntax="diff"; fi
 
         # List jobs from the current workflow run.
-        workflow_run=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs --header "$GH_API" --method GET --paginate)
+        workflow_run=$(gh api /repos/$GH_REPO/actions/runs/$GH_RUN_ID/attempts/$GH_RUN_ATTEMPT/jobs --header "$GH_API" --method GET --paginate)
 
         # Get the current job ID from the workflow run using different query methods for matrix and regular jobs.
         if [[ "$GH_MATRIX" == "null" ]]; then
@@ -396,14 +412,14 @@ runs:
             echo "Waiting to locate job ID; will try again in $retry_interval seconds."
             sleep "$retry_interval"
             retry_interval=$((retry_interval * 2))
-            workflow_run=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs --header "$GH_API" --method GET --paginate)
+            workflow_run=$(gh api /repos/$GH_REPO/actions/runs/$GH_RUN_ID/attempts/$GH_RUN_ATTEMPT/jobs --header "$GH_API" --method GET --paginate)
             job_id=$(echo "$workflow_run" | jq --raw-output --arg matrix "$matrix" '.jobs[] | select((.name | contains("(")) and ((.name | split("(")[1]) | rtrimstr(")") | rtrimstr("...") | inside($matrix))) | .id' | tail -n 1)
           done
         fi
         echo "job=$job_id" >> "$GITHUB_OUTPUT"
 
         # Add summary to the job status.
-        check_run=$(GH_TOKEN=${{ github.token }} gh api /repos/${{ github.repository }}/check-runs/${job_id} --header "$GH_API" --method PATCH --field "output[title]=${summary}" --field "output[summary]=${summary}") || true
+        check_run=$(GH_TOKEN=$GH_ACTIONS_TOKEN gh api /repos/$GH_REPO/check-runs/${job_id} --header "$GH_API" --method PATCH --field "output[title]=${summary}" --field "output[summary]=${summary}") || true
 
         # Get the step number that has status "in_progress" from the current job.
         workflow_step=$(echo "$workflow_run" | jq --raw-output --arg job_id "$job_id" '.jobs[] | select(.id == ($job_id | tonumber)) | .steps[] | select(.status == "in_progress") | .number')
@@ -412,7 +428,7 @@ runs:
         check_url=$(echo "$check_run" | jq --raw-output '.html_url // empty' 2>/dev/null) || true
         echo "check_id=$(echo "$check_run" | jq --raw-output '.id // empty' 2>/dev/null)" >> "$GITHUB_OUTPUT"
         run_url=${check_url:+${check_url}#step:${workflow_step}:1}
-        run_url=${run_url:-${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}}
+        run_url=${run_url:-$GH_SERVER_URL/$GH_REPO/actions/runs/$GH_RUN_ID}
         echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
 
         # If "tf.diff.txt" exists, display it within a "diff" block, truncated for character limit.
@@ -458,7 +474,7 @@ runs:
         <details${{ env.INPUTS_EXPAND_SUMMARY == 'true' && ' open' || '' }}><summary>${summary}</br>
 
         <!-- placeholder-4 -->
-        ###### By ${tag_actor}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
+        ###### By ${tag_actor}${GH_TRIGGERING_ACTOR} at ${GH_EVENT_TIMESTAMP} [(view log)](${run_url}).
         </summary>
 
         \`\`\`${syntax}
@@ -466,7 +482,7 @@ runs:
         \`\`\`
         </details>
         <!-- placeholder-5 -->
-        <!-- ${{ steps.identifier.outputs.name }} -->
+        <!-- $GH_IDENTIFIER_NAME -->
         <!-- placeholder-6 -->
         EOBODYTFVIAPR
         )
@@ -484,13 +500,13 @@ runs:
         rm --force tf.command.txt tf.console.txt tf.diff.txt
 
         # Exit early if there is no PR to comment on.
-        if [[ "${{ steps.identifier.outputs.pr }}" -eq 0 ]]; then
+        if [[ "$GH_PR_NUMBER" -eq 0 ]]; then
           exit 0
         fi
 
         # Check if the PR contains a bot comment with the same identifier.
-        list_comments=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --paginate)
-        bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
+        list_comments=$(gh api /repos/$GH_REPO/issues/$GH_PR_NUMBER/comments --header "$GH_API" --method GET --paginate)
+        bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "$GH_IDENTIFIER_NAME" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
 
         # Determine if a PR comment should be created.
         if [[ "$INPUTS_COMMENT_PR" == "always" ]]; then
@@ -500,7 +516,7 @@ runs:
         elif [[ ("$INPUTS_COMMENT_PR" == "on-diff" || "$INPUTS_COMMENT_PR" == "on-change") && "$INPUTS_COMMAND" != "plan" && -n "$bot_comment" ]]; then
           create_comment="true"
         elif [[ ("$INPUTS_COMMENT_PR" == "on-diff" || "$INPUTS_COMMENT_PR" == "on-change") && "$exitcode" -eq 0 && -n "$bot_comment" ]]; then
-          gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE || true
+          gh api /repos/$GH_REPO/issues/comments/${bot_comment} --header "$GH_API" --method DELETE || true
           exit 0
         fi
 
@@ -513,17 +529,17 @@ runs:
         if [[ -n "$bot_comment" ]]; then
           if [[ "$INPUTS_COMMENT_METHOD" == "update" ]]; then
             # Update existing comment.
-            pr_comment=$(gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method PATCH --field "body=${body}") || true
+            pr_comment=$(gh api /repos/$GH_REPO/issues/comments/${bot_comment} --header "$GH_API" --method PATCH --field "body=${body}") || true
             echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id // empty' 2>/dev/null)" >> "$GITHUB_OUTPUT"
           elif [[ "$INPUTS_COMMENT_METHOD" == "recreate" ]]; then
             # Delete previous comment before posting a new one.
-            gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE || true
-            pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}") || true
+            gh api /repos/$GH_REPO/issues/comments/${bot_comment} --header "$GH_API" --method DELETE || true
+            pr_comment=$(gh api /repos/$GH_REPO/issues/$GH_PR_NUMBER/comments --header "$GH_API" --method POST --field "body=${body}") || true
             echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id // empty' 2>/dev/null)" >> "$GITHUB_OUTPUT"
           fi
         else
           # Post new comment.
-          pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}") || true
+          pr_comment=$(gh api /repos/$GH_REPO/issues/$GH_PR_NUMBER/comments --header "$GH_API" --method POST --field "body=${body}") || true
           echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id // empty' 2>/dev/null)" >> "$GITHUB_OUTPUT"
         fi
 


### PR DESCRIPTION
This pull request refactors the `action.yml` workflow to consistently use environment variables for GitHub context values.

- Move all github context variables (${{ github.* }}) to env: block declarations
- Replace inline expressions in run blocks with GH_-prefixed environment variable references
- Resolves CodeQL expression injection findings across identifier, download, and post steps
- Maintains functional equivalence with improved security posture