### PR TITLE
feat: terraform/tofu subprocess module (Phase 2, exec.ts)

### DIFF
--- a/__tests__/exec.test.ts
+++ b/__tests__/exec.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ActionInputs, TFArgs } from "../src/inputs";
+
+/**
+ * Mock `@actions/exec` at the module boundary. The mock records the last call,
+ * pushes configurable output to the listeners, and returns a configurable exit
+ * code, so tests drive exit-code policy and stream capture without a real binary.
+ */
+let lastCall: { cmd: string; args: string[]; opts: exectype } | null = null;
+let nextExit = 0;
+let stdoutChunk = "";
+let stderrChunk = "";
+
+interface exectype {
+  cwd?: string;
+  env?: Record<string, string>;
+  silent?: boolean;
+  ignoreReturnCode?: boolean;
+  listeners?: { stdout?: (b: Buffer) => void; stderr?: (b: Buffer) => void };
+}
+
+const execMock = mock(async (cmd: string, args: string[], opts: exectype) => {
+  lastCall = { cmd, args, opts };
+  if (stdoutChunk !== "") opts.listeners?.stdout?.(Buffer.from(stdoutChunk));
+  if (stderrChunk !== "") opts.listeners?.stderr?.(Buffer.from(stderrChunk));
+  return nextExit;
+});
+
+mock.module("@actions/exec", () => ({ exec: execMock }));
+
+const { runTF, runPlan, runFmt, runShow, TFError } =
+  await import("../src/exec");
+
+beforeEach(() => {
+  lastCall = null;
+  nextExit = 0;
+  stdoutChunk = "";
+  stderrChunk = "";
+  execMock.mockClear();
+});
+
+function makeInputs(
+  overrides: Partial<TFArgs> = {},
+  top: Partial<ActionInputs> = {},
+): ActionInputs {
+  const args: TFArgs = {
+    autoApprove: false,
+    check: true,
+    compactWarnings: false,
+    concise: false,
+    destroy: false,
+    detailedExitcode: true,
+    diff: true,
+    forceCopy: false,
+    migrateState: false,
+    noTests: false,
+    reconfigure: false,
+    recursive: true,
+    refreshOnly: false,
+    upgrade: false,
+    backend: "",
+    backup: "",
+    chdir: "",
+    fromModule: "",
+    generateConfigOut: "",
+    get: "",
+    list: "",
+    lock: "",
+    lockTimeout: "",
+    lockfile: "",
+    parallelism: "",
+    pluginDir: "",
+    refresh: "",
+    state: "",
+    stateOut: "",
+    testDirectory: "",
+    write: "",
+    backendConfig: [],
+    replace: [],
+    target: [],
+    var: [],
+    varFile: [],
+    workspace: "",
+    ...overrides,
+  };
+  return {
+    tool: "terraform",
+    command: "plan",
+    format: false,
+    validate: false,
+    workingDirectory: "",
+    planFile: "",
+    planEncrypt: "",
+    planParity: false,
+    preservePlan: false,
+    uploadPlan: true,
+    retentionDays: "",
+    commentMethod: "update",
+    commentPr: "always",
+    commentPos: ["", "", "", "", "", ""],
+    expandDiff: false,
+    expandSummary: false,
+    hideArgs: [],
+    showArgs: [],
+    tagActor: "always",
+    prNumber: "",
+    token: "",
+    args,
+    ...top,
+  };
+}
+
+describe("runTF exit-code policy", () => {
+  test("plan -detailed-exitcode exit 2 is success with hasChanges true", async () => {
+    nextExit = 2;
+    stdoutChunk = "Plan: 1 to add, 0 to change, 0 to destroy.";
+    const result = await runTF("terraform", ["plan", "-detailed-exitcode"], {
+      okCodes: [0, 2],
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.hasChanges).toBe(true);
+    expect(result.stdout).toContain("Plan: 1 to add");
+  });
+
+  test("exit code outside okCodes throws TFError", async () => {
+    nextExit = 1;
+    stderrChunk = "Error: invalid";
+    await expect(
+      runTF("tofu", ["plan"], { okCodes: [0, 2] }),
+    ).rejects.toBeInstanceOf(TFError);
+  });
+
+  test("exit 0 has hasChanges false", async () => {
+    nextExit = 0;
+    const result = await runTF("terraform", ["init"]);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  test("allowAnyExitCode never throws", async () => {
+    nextExit = 3;
+    const result = await runTF("terraform", ["fmt", "-check"], {
+      allowAnyExitCode: true,
+    });
+    expect(result.exitCode).toBe(3);
+  });
+});
+
+describe("runTF invocation safety", () => {
+  test("passes argv as a string[] to exec, never a shell string", async () => {
+    await runTF("terraform", ["-chdir=x", "plan", "-var=a=b"]);
+    expect(lastCall?.cmd).toBe("terraform");
+    expect(lastCall?.args).toEqual(["-chdir=x", "plan", "-var=a=b"]);
+    expect(lastCall?.opts.ignoreReturnCode).toBe(true);
+  });
+
+  test("scrubs secrets from the recorded command", async () => {
+    const result = await runTF("terraform", ["plan", "-var=pass=s3cr3t"], {
+      secrets: ["s3cr3t"],
+    });
+    expect(result.command).toBe("terraform plan -var=pass=***");
+    expect(result.command).not.toContain("s3cr3t");
+  });
+
+  test("merges env over process.env and forwards cwd", async () => {
+    await runTF("terraform", ["init"], {
+      cwd: "/work",
+      env: { TF_IN_AUTOMATION: "true" },
+    });
+    expect(lastCall?.opts.cwd).toBe("/work");
+    expect(lastCall?.opts.env?.TF_IN_AUTOMATION).toBe("true");
+  });
+});
+
+describe("command wrappers", () => {
+  test("runPlan tolerates exit 2 (changes) without throwing", async () => {
+    nextExit = 2;
+    const result = await runPlan(makeInputs());
+    expect(result.hasChanges).toBe(true);
+    // -detailed-exitcode and -out=tfplan come from buildArgv
+    expect(lastCall?.args).toContain("-detailed-exitcode");
+    expect(lastCall?.args.at(-1)).toBe("-out=tfplan");
+  });
+
+  test("runFmt does not throw when files need formatting", async () => {
+    nextExit = 3;
+    const result = await runFmt(makeInputs());
+    expect(result.exitCode).toBe(3);
+    expect(lastCall?.args[0]).toBe("fmt");
+  });
+
+  test("runShow targets the plan file under -chdir and is silent", async () => {
+    await runShow(makeInputs({ chdir: "stacks/dev" }));
+    expect(lastCall?.args).toEqual(["-chdir=stacks/dev", "show", "tfplan"]);
+    expect(lastCall?.opts.silent).toBe(true);
+  });
+});

--- a/__tests__/exec.test.ts
+++ b/__tests__/exec.test.ts
@@ -6,12 +6,13 @@ import type { ActionInputs, TFArgs } from "../src/inputs";
  * pushes configurable output to the listeners, and returns a configurable exit
  * code, so tests drive exit-code policy and stream capture without a real binary.
  */
-let lastCall: { cmd: string; args: string[]; opts: exectype } | null = null;
+let lastCall: { cmd: string; args: string[]; opts: MockExecOptions } | null =
+  null;
 let nextExit = 0;
 let stdoutChunk = "";
 let stderrChunk = "";
 
-interface exectype {
+interface MockExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   silent?: boolean;
@@ -19,12 +20,14 @@ interface exectype {
   listeners?: { stdout?: (b: Buffer) => void; stderr?: (b: Buffer) => void };
 }
 
-const execMock = mock(async (cmd: string, args: string[], opts: exectype) => {
-  lastCall = { cmd, args, opts };
-  if (stdoutChunk !== "") opts.listeners?.stdout?.(Buffer.from(stdoutChunk));
-  if (stderrChunk !== "") opts.listeners?.stderr?.(Buffer.from(stderrChunk));
-  return nextExit;
-});
+const execMock = mock(
+  async (cmd: string, args: string[], opts: MockExecOptions) => {
+    lastCall = { cmd, args, opts };
+    if (stdoutChunk !== "") opts.listeners?.stdout?.(Buffer.from(stdoutChunk));
+    if (stderrChunk !== "") opts.listeners?.stderr?.(Buffer.from(stderrChunk));
+    return nextExit;
+  },
+);
 
 mock.module("@actions/exec", () => ({ exec: execMock }));
 
@@ -111,15 +114,23 @@ function makeInputs(
 }
 
 describe("runTF exit-code policy", () => {
-  test("plan -detailed-exitcode exit 2 is success with hasChanges true", async () => {
+  test("plan -detailed-exitcode exit 2 with detectChanges is success + hasChanges", async () => {
     nextExit = 2;
     stdoutChunk = "Plan: 1 to add, 0 to change, 0 to destroy.";
     const result = await runTF("terraform", ["plan", "-detailed-exitcode"], {
       okCodes: [0, 2],
+      detectChanges: true,
     });
     expect(result.exitCode).toBe(2);
     expect(result.hasChanges).toBe(true);
     expect(result.stdout).toContain("Plan: 1 to add");
+  });
+
+  test("exit 2 without detectChanges does not set hasChanges", async () => {
+    nextExit = 2;
+    const result = await runTF("terraform", ["validate"], { okCodes: [0, 2] });
+    expect(result.exitCode).toBe(2);
+    expect(result.hasChanges).toBe(false);
   });
 
   test("exit code outside okCodes throws TFError", async () => {

--- a/__tests__/exec.test.ts
+++ b/__tests__/exec.test.ts
@@ -172,6 +172,18 @@ describe("runTF invocation safety", () => {
     expect(result.command).not.toContain("s3cr3t");
   });
 
+  test("quotes only the argv tokens that contain whitespace/metacharacters", async () => {
+    const result = await runTF("terraform", [
+      "plan",
+      "-var=name=hello world",
+      "-input=false",
+    ]);
+    // safe tokens stay bare; the one with a space is single-quoted and copy-pasteable
+    expect(result.command).toBe(
+      "terraform plan '-var=name=hello world' -input=false",
+    );
+  });
+
   test("merges env over process.env and forwards cwd", async () => {
     await runTF("terraform", ["init"], {
       cwd: "/work",

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -43,6 +43,12 @@ export interface RunOptions {
   okCodes?: number[];
   /** When true, never throw on a non-zero exit (e.g. `fmt -check`). */
   allowAnyExitCode?: boolean;
+  /**
+   * Interpret exit code 2 as "changes present" (`plan -detailed-exitcode`),
+   * setting `TFResult.hasChanges`. Only `runPlan` sets this; for every other
+   * command a 2 has no special meaning and `hasChanges` stays false.
+   */
+  detectChanges?: boolean;
   /** Secret values to redact from the stored `command` (and error message). */
   secrets?: string[];
   /** Suppress live echo to the Actions log. Output is still captured. */
@@ -111,10 +117,16 @@ export async function runTF(
     throw new TFError(tool, command, exitCode, scrub(stderr, options.secrets));
   }
 
-  return { exitCode, stdout, stderr, hasChanges: exitCode === 2, command };
+  const hasChanges = (options.detectChanges ?? false) && exitCode === 2;
+  return { exitCode, stdout, stderr, hasChanges, command };
 }
 
-/** Secrets that must never appear in logs or the PR comment. */
+/**
+ * Sensitive values to redact from the stored `command` and `TFError` message.
+ * This does NOT mask the live `@actions/exec` log stream — that relies on the
+ * caller registering these values with `core.setSecret` (done when inputs are
+ * parsed / the action is wired up), which masks them everywhere in the log.
+ */
 function secretsOf(inputs: ActionInputs): string[] {
   return [inputs.planEncrypt, inputs.token].filter((value) => value !== "");
 }
@@ -145,6 +157,7 @@ export function runPlan(inputs: ActionInputs): Promise<TFResult> {
   return runTF(inputs.tool, buildArgv(inputs, "plan"), {
     ...baseOptions(inputs),
     okCodes: [0, 2],
+    detectChanges: true,
   });
 }
 

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,163 @@
+import * as exec from "@actions/exec";
+import { buildArgv, buildTFEnv } from "./args";
+import type { ActionInputs, Tool } from "./inputs";
+
+/**
+ * Terraform/OpenTofu subprocess execution (Phase 2 of the TypeScript migration).
+ *
+ * Replaces the inline `bash` invocations of the composite action's `format`,
+ * `initialize`, `validate`, `plan`, `apply`, and `show` steps. Every command is
+ * run via `@actions/exec` with an explicit `string[]` argv — never a shell
+ * string — so there is no shell parsing or word-splitting, and an input value
+ * cannot inject a second command.
+ *
+ * The recommended shape is a single low-level primitive (`runTF`) plus thin,
+ * command-specific wrappers. The primitive owns the cross-cutting concerns
+ * (stream capture, exit-code policy, secret scrubbing, env); each wrapper only
+ * declares which subcommand to build and which exit codes are acceptable.
+ */
+
+/** Result of a terraform/tofu invocation. */
+export interface TFResult {
+  /** Process exit code. */
+  exitCode: number;
+  /** Captured standard output. */
+  stdout: string;
+  /** Captured standard error. */
+  stderr: string;
+  /**
+   * True when `terraform plan -detailed-exitcode` returned 2 ("changes
+   * present"). Always false for other commands and exit codes.
+   */
+  hasChanges: boolean;
+  /** The secret-scrubbed command line, for logging and the PR comment. */
+  command: string;
+}
+
+export interface RunOptions {
+  /** Working directory; defaults to the process cwd (`-chdir` handles the rest). */
+  cwd?: string;
+  /** Extra environment merged over `process.env`. */
+  env?: Record<string, string>;
+  /** Exit codes that are NOT failures. Defaults to `[0]`. */
+  okCodes?: number[];
+  /** When true, never throw on a non-zero exit (e.g. `fmt -check`). */
+  allowAnyExitCode?: boolean;
+  /** Secret values to redact from the stored `command` (and error message). */
+  secrets?: string[];
+  /** Suppress live echo to the Actions log. Output is still captured. */
+  silent?: boolean;
+}
+
+/** Thrown when a command exits with a code outside its accepted set. */
+export class TFError extends Error {
+  constructor(
+    readonly tool: Tool,
+    readonly command: string,
+    readonly exitCode: number,
+    readonly stderr: string,
+  ) {
+    super(`${tool} exited with code ${exitCode}: ${command}`);
+    this.name = "TFError";
+  }
+}
+
+/** Replace every occurrence of each secret with `***`. */
+function scrub(text: string, secrets: readonly string[] = []): string {
+  let result = text;
+  for (const secret of secrets) {
+    if (secret !== "") result = result.split(secret).join("***");
+  }
+  return result;
+}
+
+/**
+ * Run a terraform/tofu command. Captures stdout/stderr in real time (streamed
+ * to the Actions log and accumulated for parsing), applies the exit-code policy,
+ * and returns a {@link TFResult}. Binary-agnostic: identical for `terraform` and
+ * `tofu`.
+ */
+export async function runTF(
+  tool: Tool,
+  argv: string[],
+  options: RunOptions = {},
+): Promise<TFResult> {
+  const okCodes = options.okCodes ?? [0];
+  const command = scrub([tool, ...argv].join(" "), options.secrets);
+
+  let stdout = "";
+  let stderr = "";
+
+  const execOptions: exec.ExecOptions = {
+    env: { ...process.env, ...options.env } as Record<string, string>,
+    ignoreReturnCode: true,
+    silent: options.silent ?? false,
+    listeners: {
+      stdout: (data: Buffer) => {
+        stdout += data.toString();
+      },
+      stderr: (data: Buffer) => {
+        stderr += data.toString();
+      },
+    },
+  };
+  // Assigned conditionally: `cwd` is non-optional in ExecOptions and
+  // exactOptionalPropertyTypes forbids passing `undefined`.
+  if (options.cwd !== undefined) execOptions.cwd = options.cwd;
+
+  const exitCode = await exec.exec(tool, argv, execOptions);
+
+  if (!options.allowAnyExitCode && !okCodes.includes(exitCode)) {
+    throw new TFError(tool, command, exitCode, scrub(stderr, options.secrets));
+  }
+
+  return { exitCode, stdout, stderr, hasChanges: exitCode === 2, command };
+}
+
+/** Secrets that must never appear in logs or the PR comment. */
+function secretsOf(inputs: ActionInputs): string[] {
+  return [inputs.planEncrypt, inputs.token].filter((value) => value !== "");
+}
+
+function baseOptions(inputs: ActionInputs): RunOptions {
+  return { env: buildTFEnv(inputs), secrets: secretsOf(inputs) };
+}
+
+export function runFmt(inputs: ActionInputs): Promise<TFResult> {
+  // `fmt -check` exits non-zero when files would be reformatted; that is a
+  // reportable diff, not a hard failure, so never throw.
+  return runTF(inputs.tool, buildArgv(inputs, "fmt"), {
+    ...baseOptions(inputs),
+    allowAnyExitCode: true,
+  });
+}
+
+export function runInit(inputs: ActionInputs): Promise<TFResult> {
+  return runTF(inputs.tool, buildArgv(inputs, "init"), baseOptions(inputs));
+}
+
+export function runValidate(inputs: ActionInputs): Promise<TFResult> {
+  return runTF(inputs.tool, buildArgv(inputs, "validate"), baseOptions(inputs));
+}
+
+/** `plan -detailed-exitcode`: exit code 2 ("changes present") is success. */
+export function runPlan(inputs: ActionInputs): Promise<TFResult> {
+  return runTF(inputs.tool, buildArgv(inputs, "plan"), {
+    ...baseOptions(inputs),
+    okCodes: [0, 2],
+  });
+}
+
+export function runApply(inputs: ActionInputs): Promise<TFResult> {
+  return runTF(inputs.tool, buildArgv(inputs, "apply"), baseOptions(inputs));
+}
+
+/** `show` the saved plan file (parsed by the caller, so output is not streamed). */
+export function runShow(
+  inputs: ActionInputs,
+  planFile = "tfplan",
+): Promise<TFResult> {
+  const chdir = inputs.args.chdir;
+  const argv = [...(chdir !== "" ? [`-chdir=${chdir}`] : []), "show", planFile];
+  return runTF(inputs.tool, argv, { ...baseOptions(inputs), silent: true });
+}

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -78,6 +78,23 @@ function scrub(text: string, secrets: readonly string[] = []): string {
 }
 
 /**
+ * Render an argv token for the human-readable `command` string. Shell-safe
+ * tokens are left as-is; anything containing whitespace, quotes, or other shell
+ * metacharacters is POSIX single-quoted so the rendered command is unambiguous
+ * and copy/pasteable. This only affects display — the real argv passed to
+ * `@actions/exec` is always the untouched `string[]`.
+ */
+function quoteArg(token: string): string {
+  if (token !== "" && /^[A-Za-z0-9_@%+=:,./-]+$/.test(token)) return token;
+  return `'${token.split("'").join(`'\\''`)}'`;
+}
+
+/** Join the binary and argv into a single, unambiguous display string. */
+function renderCommand(tool: Tool, argv: string[]): string {
+  return [tool, ...argv].map(quoteArg).join(" ");
+}
+
+/**
  * Run a terraform/tofu command. Captures stdout/stderr in real time (streamed
  * to the Actions log and accumulated for parsing), applies the exit-code policy,
  * and returns a {@link TFResult}. Binary-agnostic: identical for `terraform` and
@@ -89,7 +106,7 @@ export async function runTF(
   options: RunOptions = {},
 ): Promise<TFResult> {
   const okCodes = options.okCodes ?? [0];
-  const command = scrub([tool, ...argv].join(" "), options.secrets);
+  const command = scrub(renderCommand(tool, argv), options.secrets);
 
   let stdout = "";
   let stderr = "";


### PR DESCRIPTION
## Phase 2 — Subprocess module (`exec.ts`)

Implements work item #575 (epic #571, tracking #568). Builds on Phase 1 (#567, now merged). **No behavioural change**: `action.yml` is still `using: composite`; `exec.ts` is added and unit-tested but not yet wired into the runtime (that's #576), so `main.ts` and `dist/` are unchanged.

### What's here — `src/exec.ts`
A low-level primitive plus thin command wrappers (the recommended shape from the design):

- **`runTF(tool, argv, options)`** — runs terraform/tofu via `@actions/exec`, capturing stdout/stderr in real time (streamed to the log *and* accumulated for parsing). Binary-agnostic.
- **`TFResult`** — `{ exitCode, stdout, stderr, hasChanges, command }`.
- **Exit-code policy** — `okCodes` (default `[0]`); codes outside the set throw `TFError`. `runPlan` uses `okCodes: [0, 2]` so **`plan -detailed-exitcode` exit 2 ("changes present") is success with `hasChanges: true`, not a failure**.
- **`runFmt`** tolerates `fmt -check`'s non-zero "needs formatting" exit (`allowAnyExitCode`).
- **Injection-safe** — argv is always a `string[]`; never a shell string.
- **Secret scrubbing** — `plan-encrypt`/`token` values are redacted from the stored `command` (which feeds the PR comment) and from error messages.
- Wrappers: `runFmt`, `runInit`, `runValidate`, `runPlan`, `runApply`, `runShow`.

### Tests — `__tests__/exec.test.ts` (10)
`@actions/exec` mocked at the module boundary. Covers: exit-2 → success+`hasChanges`; out-of-range exit → `TFError`; `allowAnyExitCode`; argv passed as `string[]` (no shell); secret scrubbing; cwd/env forwarding; and the `runPlan`/`runFmt`/`runShow` wrappers.

### Checklist
- [x] `bun run typecheck` (strict, no `any`)
- [x] `bun run format:check`
- [x] `bun test` — 33 pass (23 Phase 1 + 10 Phase 2)
- [x] `bun run build:check` — no `dist/` drift (module not yet wired)

### Not in scope
Wiring the composite `action.yml` to call this module is **#576** (writes `tf.console.txt`/`tf.command.txt`, preserves the existing `post` step); that changes runtime behaviour and is a deliberate, separately-reviewed step.

Draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0163ag7Tva866e52BqLhGeyq)_