### PR TITLE
refactor(main): hoist subcommands list to a module-level constant

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,14 @@ import * as core from "@actions/core";
 import { buildArgv, buildTFEnv, type Subcommand } from "./args";
 import { getInputs } from "./inputs";
 
+const SUBCOMMANDS: readonly Subcommand[] = [
+  "init",
+  "validate",
+  "fmt",
+  "plan",
+  "apply",
+];
+
 /**
  * Entry point for the Terraform/OpenTofu via PR action.
  *
@@ -18,20 +26,13 @@ async function run(): Promise<void> {
   // and environment values can carry secrets and may surface in workflow logs
   // when runner debugging is enabled, so log only summaries — the subcommand,
   // the argv token count, and the environment variable names (never values).
-  const subcommands: Subcommand[] = [
-    "init",
-    "validate",
-    "fmt",
-    "plan",
-    "apply",
-  ];
   core.debug(
     `Parsed inputs for tool '${inputs.tool}', command '${inputs.command || "(none)"}'.`,
   );
   core.debug(
     `TF environment variables: ${Object.keys(buildTFEnv(inputs)).join(", ")}.`,
   );
-  for (const sub of subcommands) {
+  for (const sub of SUBCOMMANDS) {
     core.debug(`argv[${sub}]: ${buildArgv(inputs, sub).length} tokens.`);
   }
 }


### PR DESCRIPTION
## Summary

Hoists the `subcommands` list out of `run()` into a module-level `SUBCOMMANDS` constant in `src/main.ts`. The set is fixed and immutable and never depended on per-invocation state, so declaring it once at module scope (as `readonly Subcommand[]`) is cleaner and matches the "constant data lives at module scope" convention.

Pure refactor — no behavioral change (same five entries, same order, iterated read-only).

## Testing

- `tsc --noEmit` ✔
- `bun test` — 75 pass ✔

---

_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/OP5dev/TF-via-PR/security/quality/ai-findings)._
